### PR TITLE
Audit 2026-06-12 : correctifs métier + filet CI (N-02/N-03/N-07, Q-01/T-01/N-01)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # GitHub Actions (pre-existing) ───────────────────────────────────────────
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -11,5 +12,58 @@ updates:
       - "ci"
     groups:
       actions:
+        patterns:
+          - "*"
+
+  # Python engine (audit N-01) ──────────────────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      pip:
+        patterns:
+          - "*"
+
+  # Tauri frontends — npm (audit N-01) ──────────────────────────────────────
+  - package-ecosystem: "npm"
+    directories:
+      - "/tauri-prep"
+      - "/tauri-app"
+      - "/tauri-shell"
+      - "/tauri-fixture"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  # Tauri backends — cargo (audit N-01) ─────────────────────────────────────
+  - package-ecosystem: "cargo"
+    directories:
+      - "/tauri-prep/src-tauri"
+      - "/tauri-app/src-tauri"
+      - "/tauri-shell/src-tauri"
+      - "/tauri-fixture/src-tauri"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "rust"
+    groups:
+      cargo:
         patterns:
           - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,32 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
 
 permissions:
   contents: read
 
 jobs:
+  # ── Lint (ruff) — audit Q-01 ───────────────────────────────────────────────
+  lint:
+    name: Ruff lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install ruff
+        run: pip install "ruff>=0.14,<0.15"
+
+      - name: Ruff check
+        run: ruff check src tests
+
   # ── Python tests + contract freeze check ───────────────────────────────────
   test:
     name: Python tests & contract freeze
@@ -25,8 +43,8 @@ jobs:
       - name: Install project (dev extras)
         run: pip install -e ".[dev]"
 
-      - name: Run pytest
-        run: pytest -q
+      - name: Run pytest with coverage
+        run: pytest -q --cov=src/multicorpus_engine --cov-report=term-missing --cov-report=xml --cov-fail-under=35
 
       - name: Regenerate OpenAPI spec
         run: python scripts/export_openapi.py

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/sidecar_pyinstaller/
 # pytest
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 
 # Env

--- a/docs/AUDIT_2026-06-12.md
+++ b/docs/AUDIT_2026-06-12.md
@@ -1,0 +1,225 @@
+# Audit AGRAFES — 2026-06-12 (v2, consolidé après contre-vérification)
+
+**Périmètre** : dépôt complet à `373524b` (branche `development`, post-v0.2.6) — moteur Python `multicorpus_engine` (~27 k lignes), apps Tauri (`tauri-prep` ~27 k TS, `tauri-shell`, `tauri-app`, `tauri-fixture`), tests (71 fichiers, ~16,6 k lignes), CI (14 workflows), scripts/outillage, documentation.
+**Méthode** : trois vagues.
+
+1. Exploration multi-agents sur six axes (architecture, qualité, tests/CI, sécurité, frontends, docs/processus).
+2. Passe générale complémentaire sur cinq axes peu couverts (outillage/scripts, côté Rust, lecture logique du cœur moteur, concurrence/intégrité, dépendances/supply chain).
+3. **Contre-vérification adversariale de chacun des 23 findings de la v1** (trois vérificateurs indépendants chargés de réfuter), plus vérifications manuelles des allégations de bugs. Bilan : 15 confirmés, 7 nuancés, **1 réfuté et retiré** (index DB manquants — ils existent). Détail en §5.
+
+Pas de test d'intrusion, pas d'exécution de la suite. Audits précédents : `AUDIT_2026-03-26.md`, `AUDIT_2026-04-19.md`.
+
+---
+
+## 1. Synthèse exécutive
+
+Le projet est **techniquement sain et remarquablement bien gouverné pour un développement solo** : séparation moteur/CLI/sidecar propre, SQL intégralement paramétré, migrations versionnées **et correctement indexées**, modèle de concurrence solide (lock global + WAL, vérifié sans race grave), gate CI anti-croissance sur `sidecar.py`, contrat OpenAPI gelé en CI, outillage de release de qualité professionnelle, 42 ADRs, et une boucle audit → correction → trace qui fonctionne (vérifié sur échantillon).
+
+Les risques structurels, confirmés après contre-vérification :
+
+1. **`sidecar.py` est un monolithe de 9 961 lignes** (≈ 44 % du moteur) — 93 handlers HTTP dans une seule classe, sans couche de services, 66 blocs de validation copiés-collés. Le growth-gate contient le symptôme mais ne résorbe pas la dette.
+2. **Le filet CI a des trous ciblés** : aucun seuil de couverture, aucun lint/typage en CI (ni Python ni TS), `telemetry.py` et les branches cœur de `curation.py` sans tests directs, **veille de dépendances limitée à github-actions** (npm/pip/cargo non couverts par dependabot).
+3. **La documentation de pilotage décroche du code** : ROADMAP/BACKLOG figés au 20-21 avril pour des commits jusqu'au 19 mai, CHANGELOG de 1 942 lignes, ~270 artefacts d'audit trackés sans index.
+
+La passe logique a en outre confirmé **trois incohérences réelles dans le cœur métier** (undo merge/split sans re-flag des liens, surcompte `links_created`, et la perte de `text_raw` à la resegmentation — dette connue et assumée dans le HANDOFF), détaillées en §4.
+
+| Dimension | Note | Commentaire |
+|---|---|---|
+| Architecture moteur | **B+** | Couches propres, DB robuste et indexée ; monolithe sidecar |
+| Qualité du code | **B** | Erreurs bien gérées, commits transactionnels explicites ; duplication ciblée, typage partiel |
+| Tests | **B-** | Volume réel, intégration solide ; pas de seuil, modules cœur sous-testés |
+| CI/CD, release & outillage | **A** | Growth gate, contract freeze, release gate, signing 3 OS, benchs documentés |
+| Sécurité | **A-** | Aucune vulnérabilité critique (moteur **et** côté Rust) ; durcissements mineurs |
+| Concurrence/intégrité | **B+** | Lock global cohérent, WAL, FK ON ; sémantiques à documenter |
+| Frontends Tauri | **B** | Prep riche et accessible ; double client sidecar dans le shell, fichiers géants |
+| Docs & processus | **B+** | HANDOFF/ADR exemplaires ; pilotage périmé, pas de guide utilisateur |
+| Dépendances | **B** | À jour, lockfiles trackés (sauf fixture) ; dependabot quasi inactif |
+
+---
+
+## 2. Forces
+
+### Moteur et architecture
+
+- **Séparation nette moteur / CLI / sidecar** : les modules métier n'importent ni le CLI ni le sidecar ; imports lazy systématiques, aucun cycle.
+- **Couche DB exemplaire** ([db/connection.py](../src/multicorpus_engine/db/connection.py)) : WAL, `foreign_keys=ON`, `synchronous=FULL`, `busy_timeout=30000` ; 17 migrations séquentielles thread-safe ; **index pertinents présents** (`idx_alinks_*` dans 003, `idx_tokens_*` dans 012 — contrairement à ce que la v1 de cet audit affirmait) ; diagnostics complets.
+- **Commits transactionnels explicites** : 24 `conn.commit()` placés après les mutations, rollback systématique sur exception dans les importers et l'aligneur.
+- **FTS5 bien conçu** : rowid = unit_id, recovery agressif de table corrompue, **staleness dérivée en temps réel** (jamais persistée, donc jamais désynchronisée) ([indexer.py:227-255](../src/multicorpus_engine/indexer.py#L227-L255)).
+- **SQL 100 % paramétré** (vérifié) ; garde-fous ReDoS sur les regex utilisateur.
+
+### Concurrence (passe 2)
+
+- **Modèle de verrouillage cohérent** : toutes les écritures (≈ 40 sites) prennent le lock global ; les jobs async (`sidecar_jobs.py`) prennent le même lock pour leurs accès DB, avec un pattern fin pour l'annotation NLP (lock relâché pendant le calcul CPU, repris pour l'écriture). **Aucune race de corruption identifiée.**
+- Requêtes fédérées multi-DB : connexions externes validées (resolve + is_file), isolées et fermées en `finally` ([sidecar.py:1586-1601](../src/multicorpus_engine/sidecar.py#L1586)).
+
+### Sécurité — moteur et Rust
+
+- Binding loopback forcé, token `secrets.token_urlsafe(24)` comparé via `hmac.compare_digest`, portfile `chmod 0o600`, endpoints mutateurs tous protégés, anti-traversée sur les exports, caps de taille, `defusedxml` sur tous les parsings d'entrée, aucun `eval`/`exec`/`pickle`.
+- **Côté Rust (tauri-shell) sain** : `sidecar_fetch_loopback` whitelist les hôtes loopback, lecture du portfile restreinte au seul nom `.agrafes_sidecar.json` (durcie suite à l'audit AGRAFES-3, commit `0c4dc78`), lecture télémétrie bornée à 5 MiB, update-check GitHub avec validation `[a-zA-Z0-9._-]` du owner/repo (ADR-039), shutdown propre via `on_window_event` + registre `Arc<Mutex<…>>`. Cargo.lock trackés (sauf fixture).
+- `docs/SIDECAR_SECURITY_POSTURE.md` correspond au code réel.
+
+### CI/CD, release et outillage (passe 2)
+
+- **`sidecar-growth-gate.yml`** (+500 lignes / 90 j, override tracé), **contract freeze** OpenAPI, release gate complet (`scripts/release_gate.py` : pytest + builds npm + QA sur DB démo, timeouts et erreurs capturés), checklist, versions synchronisées par `bump_version.py` (semver validé, dry-run), 52 tags signés.
+- **Chaîne de packaging solide** : `build_sidecar.py` (exclusions PyInstaller explicites, bundling spaCy maîtrisé, placement atomique des artefacts, manifest sha256), budget de taille de binaire imposé en CI (`check_sidecar_size_budget.py`), signing Windows/macOS avec secrets en base64 → tempfile → cleanup, notarisation macOS.
+- Benchmarks reproductibles et documentés (FTS profile avec PRAGMAs recommandés, qualité de segmentation avec seuils F1, startup sidecar en cron quotidien).
+
+### Frontends
+
+- Travail d'accessibilité substantiel sur Prep (109 `aria-*`, 46 `role=`, reverts assumés) ; gestion d'erreurs réseau systématique ; 18 fichiers Vitest sur la logique Prep.
+- **Échantillonnage XSS rassurant** : les interpolations `innerHTML` examinées (données de corpus : titres, labels, messages) passent toutes par `escHtml()`/`textContent` (655 occurrences d'échappement sur l'ensemble des fronts).
+
+### Documentation
+
+- `HANDOFF_PREP.md`/`HANDOFF_SHELL.md` d'une qualité rare (dettes nommées explicitement — la « tension structurelle » de la resegmentation y est assumée) ; 42 ADRs cités depuis le code ; télémétrie locale privacy-friendly ; **le CHANGELOG référence les IDs des findings d'audit** (« C-08→C-13 : XSS corrigé », « M-01 : MAX_BODY_SIZE ») — la traçabilité avant existe, c'est la vue inverse qui manque.
+
+---
+
+## 3. Faiblesses (v1 corrigée après contre-vérification)
+
+Sévérité : 🔴 structurel · 🟠 important · 🟡 mineur. Les chiffres ci-dessous sont les chiffres **recomptés** en passe 2.
+
+### Architecture (A)
+
+| ID | Sév. | Constat | Preuve |
+|---|---|---|---|
+| A-01 | 🔴 | **`sidecar.py` monolithe** : 9 961 lignes, 93 méthodes `_handle_*` dans une seule classe, dispatch if/elif de 186 lignes dans `do_POST`, aucune couche de services. Testable uniquement via HTTP. | `sidecar.py:387-9961`, dispatch 722-907 |
+| A-02 | 🟠 | `/import/preview` réimplémente les importers : regex `_NUMBERED_RE` identique dupliquée (`sidecar.py:2458` vs [docx_numbered_lines.py:30](../src/multicorpus_engine/importers/docx_numbered_lines.py#L30)), idem rich-text/TEI/ODT. | `sidecar.py:2450-2543` |
+| A-03 | 🟠 | **66 blocs** de validation manuelle (`isinstance` + `_send_error`) au lieu d'un validateur de schéma. | recompte grep |
+| A-04 | 🟡 | Attributs dynamiques non typés sur `HTTPServer` (`self._httpd.conn = …`). *(L'affirmation v1 « auto-commit implicite » était fausse : les commits sont explicites et bien placés.)* | `sidecar.py:9147-9157` |
+| ~~A-05~~ | — | **RETIRÉ (réfuté en passe 2)** : les index secondaires existent — `idx_alinks_pivot/target/ext/docs` (003_alignment.sql), `idx_tokens_unit/lemma/upos` (012_tokens.sql). | migrations vérifiées |
+
+### Qualité du code (Q)
+
+| ID | Sév. | Constat | Preuve |
+|---|---|---|---|
+| Q-01 | 🟠 | **Aucune config lint/typage nulle part** : pas de `[tool.ruff]`/`[tool.mypy]`, aucun `.eslintrc*`, et **zéro occurrence de ruff/mypy/eslint dans les 14 workflows CI** (vérifié). | `pyproject.toml`, `.github/workflows/` |
+| Q-02 | 🟠 | Fonctions géantes : `_handle_import` 242 l. (9 branches), `_handle_query` 221 l. ; `_build_hits` (71 l.) vs `_build_hits_regex` (62 l.) ~70 lignes dupliquées. | `sidecar.py:2052-2293`, `1434-1654` ; `query.py:386-520` |
+| Q-03 | 🟡 | `_compute_file_hash` redéfini dans **5 importers** (conllu, docx_numbered_lines, docx_paragraphs, tei_importer, txt) — pire que l'estimation v1 (≥3) ; duplication paragraphe DOCX/ODT (~80 l.). | grep vérifié |
+| Q-04 | 🟡 | Typage hétérogène : `cli.py` ~93 % de retours annotés, `query.py` ~35 %, importers ~20 % ; pas de TypedDict pour les shapes des contrats. *(L'exemple v1 `_CTX_TRIM` était mauvais : la constante est documentée à `sidecar.py:3092-3093`.)* | `query.py:386` |
+| Q-05 | 🟡 | Matcher CQL récursif : la profondeur est bornée par le nombre de specs et `min/max_repeat` est borné par la longueur de la phrase ([token_query.py:77-79](../src/multicorpus_engine/token_query.py#L77-L79)) — le risque résiduel se limite aux requêtes pathologiques (nombreuses specs à quantificateurs), sans cap global documenté. *(Reformulé : la v1 disait « sans garde », c'était inexact.)* | `token_query.py:65-98` |
+
+### Tests et CI (T)
+
+| ID | Sév. | Constat | Preuve |
+|---|---|---|---|
+| T-01 | 🔴 | **Pas de seuil de couverture** : ni dans `addopts`, ni dans `ci.yml` (`pytest -q`), ni dans le release gate. | `pyproject.toml:46-49`, `ci.yml:28-29` |
+| T-02 | 🟠 | **Couverture indirecte seulement pour les modules à risque** : `curation.py` est importé par 5 fichiers de tests et `telemetry.py` touché via `test_analyze_undo_soak.py`, mais les branches cœur restent sans test direct — locking fichier POSIX/Windows de la télémétrie, règles de curation aux limites. *(Nuancé : la v1 disait « zéro test », c'était exagéré.)* | grep tests/ vérifié |
+| T-03 | 🟡 | Nommage par incrément limité à une minorité : **11 fichiers** versionnés (`test_v2.py`, `test_sidecar_v03…v15.py`) contre ~50 nommés par domaine. Utiles comme gel d'API mais à isoler (ex. `tests/contracts/`). *(Dégradé de 🟠 à 🟡 : 82 % de la suite est déjà nommée par domaine.)* | listing tests/ |
+| T-04 | 🟡 | Fragilités timing : 23 `time.sleep` de polling dans les tests sidecar ; 8 tests échouent en local sans `NO_PROXY=127.0.0.1,localhost` (artefact proxy documenté au commit `3ea1005` — passent en CI). | `test_sidecar_api_contract.py:55` |
+| T-05 | 🟠 | E2E Tauri quasi inexistant : smoke JSON du sidecar packagé ; smoke GUI en `workflow_dispatch` manuel, défaut `false` ; aucun Playwright/WebDriver invoqué. | `tauri-e2e-fixture.yml:106-186` |
+
+### Sécurité (S) — aucun finding critique
+
+| ID | Sév. | Constat | Preuve |
+|---|---|---|---|
+| S-01 | 🟡 | Pas de validation du header `Host`/`Origin` (grep vide dans sidecar.py) : DNS rebinding théorique, limité aux endpoints de lecture (les écritures exigent le token). Durcissement ≈ 5 lignes. | `do_GET`/`do_POST` |
+| S-02 | 🟡 | Race POSIX sur le portfile : `write_text()` puis `chmod(0o600)`, aucune mitigation (`O_EXCL`/umask absents — grep vérifié). | `sidecar.py:9247-9261` |
+| S-03 | 🟡 | 384 usages d'`innerHTML` (36 fichiers). **Mitigé en pratique** : l'échantillonnage des interpolations de données de corpus n'a trouvé aucun cas non échappé (helpers `escHtml`/`textContent` : 655 occurrences). Le risque est la **régression future** : aucune règle lint ne l'interdit. | échantillon vérifié 2026-06-12 |
+| S-04 | 🟡 | `exporters/tei.py:26` importe `xml.etree` non défusé — construction seulement, aucun `.parse()`/`.fromstring()` dans le fichier (vérifié) : risque nul aujourd'hui, incohérence de principe. | `tei.py:26` |
+
+### Frontends Tauri (U)
+
+| ID | Sév. | Constat | Preuve |
+|---|---|---|---|
+| U-01 | 🟠 | **Aggravé en passe 2** : non seulement `sidecarClient.ts` est dupliqué et divergent entre `tauri-app` (1 434 l.) et `tauri-prep` (2 984 l.), mais **`tauri-shell` importe LES DEUX** — celui de tauri-app à 7 endroits de `shell.ts` (956, 958, 2047, 2373, 2909, 3017, 3165) et celui de prep dans `rechercheModule.ts:10` et `shell.ts:3166`. Deux états de connexion module-level coexistent donc dans la même app (risque de double spawn / état incohérent). | grep vérifié |
+| U-02 | 🟠 | Écrans monolithiques Prep : `CurationView.ts` ~3 800 l., `MetadataScreen.ts` ~3 200 l., `SegmentationView.ts` ~2 671 l. | `tauri-prep/src/screens/` |
+| U-03 | 🟡 | `tauri-app` : 0 fichier de test pour 8 112 lignes TS. | find vérifié |
+| U-04 | 🟡 | Signalisation de statut **fragmentée mais pas absente** : `tauri-prep/README.md` pointe vers le shell, `tauri-app/README.md` dit « V0 — fonctionnel, non publié » sans mentionner le shell. *(Nuancé vs v1.)* | READMEs vérifiés |
+| U-05 | 🟡 | i18n absent (aucune lib, chaînes FR en dur). Non bloquant — produit francophone. | package.json |
+
+### Documentation et processus (D)
+
+| ID | Sév. | Constat | Preuve |
+|---|---|---|---|
+| D-01 | 🟠 | ROADMAP « Last updated: 2026-04-21 », BACKLOG « 2026-04-20 », dernier commit 2026-05-19 : 29 jours de dérive, items « Now » déjà livrés. | en-têtes vérifiés |
+| D-02 | 🟠 | CHANGELOG : 1 942 lignes, 82 sections, sans archivage. | wc/grep vérifiés |
+| D-03 | 🟠 | 267 artefacts trackés sans index : `artifacts/ui-audit/` 115 fichiers (56 PNG + `divergences.json` 842 KB, état de mars), `audit/` 152 fichiers — **aucun README** dans l'un ou l'autre. `.git` = 46 MB (raisonnable, mais trajectoire). | git ls-files vérifié |
+| D-04 | 🟡 | Traçabilité audit → action **à moitié construite** : le CHANGELOG référence les findings (C-08→C-13, M-01…) mais la vue inverse (finding → statut → commit) n'existe pas — il faut un `git log -S` pour savoir si un item est clos. *(Dégradé de 🟠 à 🟡.)* | CHANGELOG:352 |
+| D-05 | 🟡 | Aucun guide utilisateur final (aucun fichier GUIDE/USER/MANUAL ; toutes les docs ciblent développeurs/agents). | docs/ vérifié |
+| D-06 | 🟡 | **Corrigé en passe 2** : il y a en réalité deux vecteurs de version bien alignés (engine 0.2.6 = shell 0.2.6 ; contrat API) — mais `sidecar_contract.py` porte **deux constantes divergentes** : `API_VERSION = "1.6.23"` (renvoyée par l'API) et `CONTRACT_VERSION = "1.6.27"` (ligne 15-16), distinction non documentée. | `sidecar_contract.py:15-16` |
+
+---
+
+## 4. Nouveaux findings (passe générale 2)
+
+| ID | Sév. | Constat | Preuve | Statut vérif. |
+|---|---|---|---|---|
+| N-01 | 🟠 | **Dependabot ne couvre que `github-actions`** : aucun écosystème npm/pip/cargo configuré, zéro commit de bump de dépendance dans l'historique. La veille sécurité des trois écosystèmes applicatifs est entièrement manuelle. | `.github/dependabot.yml:1-16` | agent, config lue |
+| N-02 | 🟡 | **Undo merge/split ne re-flag pas les liens d'alignement** : `_undo_curation_apply` marque `source_changed_at` ([undo.py:156](../src/multicorpus_engine/undo.py#L156)) mais `_undo_merge_units` et `_undo_split_unit` retournent `"alignments_reflagged": 0` en dur ([undo.py:223](../src/multicorpus_engine/undo.py#L223), [267](../src/multicorpus_engine/undo.py#L267)) alors que le texte des unités restaurées a changé — l'utilisateur n'est pas averti que les liens sont à revoir. | vérifié manuellement | **confirmé** |
+| N-03 | 🟡 | **`links_created` surcompte** : `report.links_created = len(links)` est affecté après un `INSERT OR IGNORE` — les doublons ignorés sont quand même comptés ([aligner.py:279-294](../src/multicorpus_engine/aligner.py#L279-L294)). Un réalignement sans purge affiche N liens « créés » pour 0 insertion réelle. Correctif trivial : sommer `cur.rowcount`. | vérifié manuellement | **confirmé** |
+| N-04 | 🟡 | **Resegmentation : `text_raw` écrasé et liens supprimés** — les nouvelles unités sont créées avec `text_raw = text_norm = segment` ([segmenter.py:324](../src/multicorpus_engine/segmenter.py#L324), [527](../src/multicorpus_engine/segmenter.py#L527)) et tous les `alignment_links` du document sont `DELETE`. Dette **connue et assumée** (HANDOFF « tension structurelle ») — consignée ici pour suivi : à arbitrer un jour (préserver text_raw d'origine dans meta_json ?). | vérifié manuellement | **confirmé (connu)** |
+| N-05 | 🟡 | **Statut de job mensonger au shutdown** : un job dont le `commit` est passé juste avant `cancel_all()` est rapporté `canceled` alors que ses effets sont en base ([sidecar_jobs.py:152-153](../src/multicorpus_engine/sidecar_jobs.py#L152), `sidecar.py:9228-9230`). Données cohérentes, statut faux — le front peut croire qu'un index/curate n'a pas eu lieu. | agent (lecture) | plausible, à confirmer |
+| N-06 | 🟡 | **`tauri-fixture` sans lockfiles** : ni `package-lock.json` ni `Cargo.lock` trackés ; la CI fait `npm install` (pas `npm ci`) → builds E2E non reproductibles. | `tauri-e2e-fixture.yml:162` | vérifié git ls-files |
+| N-07 | 🟡 | **Version désynchronisée tauri-shell** : `Cargo.toml` = 0.1.28 vs `tauri.conf.json` = 0.2.6 — `bump_version.py` ne met pas à jour le Cargo.toml. | vérifié manuellement | **confirmé** |
+| N-08 | 🟢 | Divers mineurs : sémantique de `_reflag_alignment_links` à arbitrer (flag `source_changed_at` aussi quand l'unité modifiée est *cible* du lien — [undo.py:139-143](../src/multicorpus_engine/undo.py#L139-L143)) ; lock télémétrie Windows bloquant sans timeout (`msvcrt.LK_LOCK`) ; release-gate sur Python 3.12 alors que CI/build sont en 3.11 ; `scripts/read_manifest_field.py` sans gestion KeyError ; capability `args: true` sur le spawn sidecar (sûr en pratique, args codés en dur côté TS) ; snapshot de curation limité à `text_norm` (un changement concurrent d'`external_id` entre apply et undo n'est pas couvert). | divers | agents (lecture) |
+
+**Points également ressortis comme sains en passe 2** : aucune division par zéro dans stats (protégées), normalisation Unicode cohérente import → index → query, validation des `db_paths` fédérés correcte, lecture du portfile côté Rust whitelistée, gestion des PID périmés robuste.
+
+---
+
+## 5. Bilan de la contre-vérification (passe 2 sur les findings v1)
+
+| Verdict | Findings | Conséquence |
+|---|---|---|
+| ✅ Confirmés (15) | A-01, A-02, A-03, Q-01, Q-02, Q-03 (aggravé : 5 et non ≥3), T-01, T-04, T-05, S-01, S-02, U-01 (aggravé : double import dans le shell), U-02, U-03, D-01, D-02, D-03, D-05 | inchangés ou précisés |
+| 🟡 Nuancés (7) | A-04 (auto-commit : faux), Q-04 (`_CTX_TRIM` documenté), Q-05 (gardes présentes), T-02 (tests indirects existent), T-03 (11 fichiers sur ~60, dégradé), S-03 (mitigé en pratique), U-04 (signalisation partielle), D-04 (traçabilité avant existe, dégradé), D-06 (2 vecteurs, pas 4 — mais constantes divergentes) | reformulés en §3 |
+| 🔴 Réfuté (1) | A-05 (index manquants) — les index existent dans 003 et 012 | **retiré** |
+
+Erreurs corrigées au passage : dispatch `do_POST` = 186 lignes (pas ~240) ; blocs de validation = 66 (pas ~50) ; `_handle_query` = 221 lignes.
+
+---
+
+## 6. Recommandations priorisées (révisées)
+
+### P0 — structurel (à engager maintenant, par tranches)
+
+1. **Extraire une couche de services du sidecar** (A-01, A-02, A-03, Q-02) — inchangé, chantier n°1. Migrer un domaine par sprint en commençant par **Import** (résout la duplication A-02 en même temps). Les handlers deviennent des adaptateurs HTTP de ~10 lignes ; la logique devient testable sans serveur, ce qui débloque T-02.
+   *Effort : 4-6 tranches de ~1 j.*
+2. **Mettre la CI au niveau du reste du processus** (Q-01, T-01, S-03, N-01) :
+   - `[tool.ruff]` + job `ruff check src tests` ; règle ESLint interdisant `innerHTML` non assaini (`no-unsanitized`) ;
+   - `--cov=src/multicorpus_engine --cov-fail-under=<actuel-2pts>` remonté par paliers ;
+   - **étendre dependabot.yml aux écosystèmes npm, pip et cargo** (weekly, groupé) — 15 lignes de YAML.
+   *Effort : ~1 j.*
+3. **Tests directs `telemetry.py` + branches cœur `curation.py`** (T-02) — ~20 tests ciblés (locking POSIX/Windows, fire-and-forget, règles aux limites).
+   *Effort : 2 j.*
+
+### P1 — important (4-6 semaines)
+
+4. **Unifier `sidecarClient.ts`** (U-01) — priorité renforcée par la découverte du double import dans le shell : extraire `shared/` (types, runner/spawn/token, HTTP) et faire converger les 3 apps dessus, en commençant par faire pointer tout `shell.ts` sur un seul client.
+   *Effort : 2-3 j + tests.*
+5. **Corriger les trois incohérences métier confirmées** (N-02, N-03, N-07) : re-flag des liens dans `_undo_merge_units`/`_undo_split_unit` (réutiliser `_reflag_alignment_links`, ~10 lignes + tests) ; `links_created` basé sur `rowcount` ; `bump_version.py` étendu au `Cargo.toml` du shell. Vérifier N-05 (statut de job au shutdown) et le documenter ou le corriger.
+   *Effort : 1 j.*
+6. **Réorganiser la suite de tests** (T-03, allégé) : déplacer les 11 fichiers versionnés sous `tests/contracts/`, créer les nouveaux tests par domaine. *Effort : ½ j de structure.*
+7. **Pilotage et traçabilité** (D-01, D-04, D-06) : rafraîchir ROADMAP/BACKLOG post-v0.2.6 ; créer `docs/AUDIT_FOLLOW_UP.md` (finding → statut → commit) pour les trois audits ; archiver le CHANGELOG < 0.1.0 (D-02) ; documenter (ou unifier) `API_VERSION` vs `CONTRACT_VERSION`.
+   *Effort : ½ j à 1 j.*
+8. **Durcissements sécurité mineurs** (S-01, S-02, S-04) : validation `Host`, portfile en `O_CREAT|O_EXCL|0o600`, `defusedxml` dans `tei.py`. *Effort : ½ j.*
+
+### P2 — fond de panier (opportuniste)
+
+9. Lockfiles pour `tauri-fixture` + `npm ci` en CI (N-06).
+10. Nettoyer/indexer les artefacts trackés (D-03) : README d'index dans `audit/` et `artifacts/`, sortir les PNG/JSON d'état vers des release assets.
+11. Découper les écrans géants de Prep au fil des évolutions (U-02) ; premiers tests Vitest sur `tauri-app` (U-03).
+12. Guide utilisateur final (D-05) ; bandeau de statut dans `tauri-app/README.md` (U-04).
+13. mypy progressif (`check_untyped_defs`, exclusion temporaire de sidecar.py) — prérequis de sécurité pour P0-1 (Q-04, A-04).
+14. Arbitrer la dette resegmentation (N-04) : décider si `text_raw` d'origine doit survivre (copie dans `meta_json` des nouvelles unités ?) et tracer la décision en ADR.
+
+---
+
+## 7. Suivi des audits précédents (échantillon vérifié)
+
+| Finding antérieur | Statut | Preuve |
+|---|---|---|
+| B7 (2026-04-19) — XSS `innerHTML` ActionsScreen | ✅ Corrigé | `td.textContent` ([ActionsScreen.ts:679-682](../tauri-prep/src/screens/ActionsScreen.ts#L679-L682)), commit `84e92be`, CHANGELOG « C-08→C-13 » — re-confirmé en passe 2 |
+| B6 — rollback import | ✅ Corrigé | ADR-040, try/except/rollback dans les importers |
+| C-01 (AGRAFES-3) — lecture fichier arbitraire côté Rust | ✅ Corrigé | `read_sidecar_portfile` whitelisté, commit `0c4dc78` |
+| M-01 (2026-03-26) — zéro test frontend | ✅ Largement résorbé (Prep) | 18 fichiers Vitest ; reste ouvert pour `tauri-app` (U-03) |
+| W-01/W-02 — monolithes | ⚠️ Partiellement | Extractions faites côté Prep ; `sidecar.py` et les écrans géants demeurent (A-01, U-02) |
+
+---
+
+## 8. Conclusion
+
+La contre-vérification renforce le diagnostic d'ensemble plutôt qu'elle ne l'affaiblit : sur 23 findings, un seul était faux (A-05, retiré), et les nuances apportées (tests indirects existants, nommage majoritairement sain, XSS mitigé en pratique) vont toutes dans le sens d'un projet **plus solide que la moyenne**. En sens inverse, la passe générale a confirmé trois incohérences métier réelles mais petites (undo merge/split, surcompte de liens, version shell), une vraie lacune de supply chain (dependabot inactif sur npm/pip/cargo) et un point d'architecture front aggravé (le shell consomme deux clients sidecar divergents).
+
+La hiérarchie des chantiers ne change pas : **sidecar.py → filet CI (lint + couverture + dependabot) → pilotage documentaire**, avec désormais une journée de correctifs métier ciblés (P1-5) au-dessus de la pile. Les trois P0 restent une à deux semaines de travail étalées, sans gel des features.

--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -43,12 +43,10 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | A-02 | 🟠 | P0-1 | 🟦 partiel | `/import/preview` réimplémente les importers (`sidecar.py:2458`). Le router `dispatch_import` (branche `feat/sharedocs-ingestion-p1`) unifie l'**import** mais pas le **preview** |
 | A-03 | 🟠 | P0-1 | ⬜ ouvert | 66 blocs de validation manuelle (pas de validateur de schéma) |
 | A-04 | 🟡 | P2-13 | ⬜ ouvert | Attributs dynamiques non typés sur `HTTPServer` |
-| Q-01 | 🟠 | P0-2 | ⬜ ouvert | Aucune config lint/typage (ruff/mypy/eslint), zéro en CI |
 | Q-02 | 🟠 | P0-1 | ⬜ ouvert | Fonctions géantes ; `_build_hits` vs `_build_hits_regex` (~70 l. dupliquées) |
 | Q-03 | 🟡 | — | ⬜ ouvert | `_compute_file_hash` redéfini dans 5 importers ; dup DOCX/ODT |
 | Q-04 | 🟡 | P2-13 | ⬜ ouvert | Typage hétérogène ; pas de TypedDict pour les shapes de contrat |
 | Q-05 | 🟡 | — | ⬜ ouvert | Matcher CQL : pas de cap global documenté (gardes présentes) |
-| T-01 | 🔴 | P0-2 | ⬜ ouvert | Pas de seuil de couverture (addopts/CI/release-gate) |
 | T-02 | 🟠 | P0-3 | ⬜ ouvert | Branches cœur `telemetry.py` / `curation.py` sans test direct |
 | T-03 | 🟡 | P1-6 | ⬜ ouvert | 11 fichiers de tests versionnés à isoler sous `tests/contracts/` |
 | T-04 | 🟡 | — | ⬜ ouvert | Fragilités timing (23 `time.sleep`) ; 8 tests exigent `NO_PROXY` en local |
@@ -67,10 +65,12 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | D-03 | 🟠 | P2-10 | ⬜ ouvert | 267 artefacts trackés sans index (`audit/`, `artifacts/`) |
 | D-05 | 🟡 | P2-12 | ⬜ ouvert | Aucun guide utilisateur final |
 | D-06 | 🟡 | P1-7 | ⬜ ouvert | `API_VERSION` (1.6.23) vs `CONTRACT_VERSION` (1.6.27) — distinction non documentée |
-| N-01 | 🟠 | P0-2 | ⬜ ouvert | Dependabot ne couvre que `github-actions` (npm/pip/cargo absents) |
 | N-04 | 🟡 | P2-14 | 🔵 connu/assumé | Resegmentation écrase `text_raw` + supprime les liens (dette HANDOFF) ; à arbitrer en ADR |
 | N-06 | 🟡 | P2-9 | ⬜ ouvert | `tauri-fixture` sans lockfiles ; CI en `npm install` |
 | N-08 | 🟢 | — | ⬜ ouvert | Divers mineurs (sémantique reflag cible, lock télémétrie Windows, release-gate 3.12, etc.) |
+| DEP-1\* | 🟢 | — | 🔵 suivi dependabot | `esbuild`/`vite`/`postcss` (devDeps, **non embarqués**) — vulns *dev-only* (CORS serveur de dev esbuild ; postcss = CSS maison). « high » contextuel = faible. Correctif = `vite@8` (major) via PR dependabot. Découvert en câblant N-01. |
+
+\*Item dérivé (pas un finding d'audit), tracé pour ne pas perdre un « high » connu.
 
 ---
 

--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -55,7 +55,7 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | T-05 | 🟠 | — | ⬜ ouvert | E2E Tauri quasi inexistant (pas de Playwright/WebDriver) |
 | S-01 | 🟡 | P1-8 | ⬜ ouvert | Pas de validation `Host`/`Origin` (DNS rebinding théorique, lecture seule) |
 | S-02 | 🟡 | P1-8 | ⬜ ouvert | Race POSIX sur le portfile (`O_EXCL`/umask absents) |
-| S-03 | 🟡 | P0-2 | ⬜ ouvert | 384 `innerHTML` ; mitigé en pratique, mais aucune règle lint anti-régression |
+| S-03 | 🟡 | P0-2 | 🟦 partiel | Sink type-safe `setHtml`/`safeHtml\`\`` + ESLint no-unsanitized (prep) ; 3 fichiers migrés, `f858c78`. Aucun vrai XSS trouvé (escapers tous vérifiés). **Reste** : 92 sites des 4 écrans géants + app/shell + job CI bloquant. Décision de reprise en attente (grind complet vs suppressions pour les géants). |
 | S-04 | 🟡 | P1-8 | ⬜ ouvert | `exporters/tei.py` importe `xml.etree` non défusé (risque nul aujourd'hui) |
 | U-01 | 🟠 | P1-4 | ⬜ ouvert | `sidecarClient.ts` dupliqué/divergent ; le shell importe **les deux** clients |
 | U-02 | 🟠 | P2-11 | ⬜ ouvert | Écrans Prep monolithiques (Curation ~3 800 l., Metadata ~3 200 l.) |

--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -1,0 +1,88 @@
+# Suivi des audits — finding → statut → commit
+
+**But.** Vue *inverse* manquante (finding D-04 de l'audit 2026-06-12). Le CHANGELOG
+référence déjà les findings dans le sens **commit → finding** (« C-08→C-13 : XSS
+corrigé ») ; ce fichier fournit le sens **finding → statut → commit**, pour savoir
+d'un coup d'œil si un item est clos sans avoir à lancer un `git log -S`.
+
+**Légende statut.**
+✅ corrigé · 🟦 partiel · 📝 documenté (assumé, sans correctif) · 🔵 connu/assumé (dette) · ⬜ ouvert · 🔎 à vérifier · ❌ réfuté / retiré
+
+**Convention.** Mettre ce fichier à jour **dans le même commit** que le correctif
+d'un finding (au même titre que le CHANGELOG). Les priorités (P0/P1/P2) reprennent
+le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
+
+> État des correctifs ci-dessous : commit `ae78207` est sur la branche
+> `fix/audit-business-logic` (depuis `development` à `373524b`), **en attente de
+> merge** dans `development` à la rédaction de ce fichier.
+
+---
+
+## Audit 2026-06-12 (post-v0.2.6, base `373524b`) — `AUDIT_2026-06-12.md`
+
+### Traités
+
+| ID | Sév | Prio | Statut | Preuve / commit |
+|----|-----|------|--------|-----------------|
+| N-02 | 🟡 | P1-5 | ✅ corrigé | Re-flag des liens dans `_undo_merge_units`/`_undo_split_unit` + purge FK avant DELETE. Étendu à `_undo_resegment` (même crash FK, trouvé en revue). `ae78207`, tests `test_undo.py` |
+| N-03 | 🟡 | P1-5 | ✅ corrigé | `links_created` via `cur.rowcount` aux 4 stratégies d'alignement (était `len(links)`). `ae78207`, test `test_alignment.py::test_align_links_created_excludes_ignored_duplicates` |
+| N-05 | 🟡 | P1-5 | 📝 documenté | Race statut de job au shutdown : commentaire `sidecar_jobs.py` (~ligne 152). Fix fidèle = signal de commit côté runner, hors périmètre. `ae78207` |
+| N-07 | 🟡 | P1-5 | ✅ corrigé | `bump_version.py` met à jour le `Cargo.toml` du shell (regex ancrée) + resync `0.1.28 → 0.2.6`. `ae78207` |
+| D-04 | 🟡 | P1-7 | ✅ corrigé | **Ce fichier** (vue inverse finding→statut→commit) |
+| A-05 | — | — | ❌ retiré | Réfuté en passe 2 : les index secondaires existent (`003_alignment.sql`, `012_tokens.sql`) |
+
+### Ouverts
+
+| ID | Sév | Prio | Statut | Constat (résumé) |
+|----|-----|------|--------|------------------|
+| A-01 | 🔴 | P0-1 | ⬜ ouvert | `sidecar.py` monolithe (9 961 l., 93 handlers, pas de couche services) |
+| A-02 | 🟠 | P0-1 | 🟦 partiel | `/import/preview` réimplémente les importers (`sidecar.py:2458`). Le router `dispatch_import` (branche `feat/sharedocs-ingestion-p1`) unifie l'**import** mais pas le **preview** |
+| A-03 | 🟠 | P0-1 | ⬜ ouvert | 66 blocs de validation manuelle (pas de validateur de schéma) |
+| A-04 | 🟡 | P2-13 | ⬜ ouvert | Attributs dynamiques non typés sur `HTTPServer` |
+| Q-01 | 🟠 | P0-2 | ⬜ ouvert | Aucune config lint/typage (ruff/mypy/eslint), zéro en CI |
+| Q-02 | 🟠 | P0-1 | ⬜ ouvert | Fonctions géantes ; `_build_hits` vs `_build_hits_regex` (~70 l. dupliquées) |
+| Q-03 | 🟡 | — | ⬜ ouvert | `_compute_file_hash` redéfini dans 5 importers ; dup DOCX/ODT |
+| Q-04 | 🟡 | P2-13 | ⬜ ouvert | Typage hétérogène ; pas de TypedDict pour les shapes de contrat |
+| Q-05 | 🟡 | — | ⬜ ouvert | Matcher CQL : pas de cap global documenté (gardes présentes) |
+| T-01 | 🔴 | P0-2 | ⬜ ouvert | Pas de seuil de couverture (addopts/CI/release-gate) |
+| T-02 | 🟠 | P0-3 | ⬜ ouvert | Branches cœur `telemetry.py` / `curation.py` sans test direct |
+| T-03 | 🟡 | P1-6 | ⬜ ouvert | 11 fichiers de tests versionnés à isoler sous `tests/contracts/` |
+| T-04 | 🟡 | — | ⬜ ouvert | Fragilités timing (23 `time.sleep`) ; 8 tests exigent `NO_PROXY` en local |
+| T-05 | 🟠 | — | ⬜ ouvert | E2E Tauri quasi inexistant (pas de Playwright/WebDriver) |
+| S-01 | 🟡 | P1-8 | ⬜ ouvert | Pas de validation `Host`/`Origin` (DNS rebinding théorique, lecture seule) |
+| S-02 | 🟡 | P1-8 | ⬜ ouvert | Race POSIX sur le portfile (`O_EXCL`/umask absents) |
+| S-03 | 🟡 | P0-2 | ⬜ ouvert | 384 `innerHTML` ; mitigé en pratique, mais aucune règle lint anti-régression |
+| S-04 | 🟡 | P1-8 | ⬜ ouvert | `exporters/tei.py` importe `xml.etree` non défusé (risque nul aujourd'hui) |
+| U-01 | 🟠 | P1-4 | ⬜ ouvert | `sidecarClient.ts` dupliqué/divergent ; le shell importe **les deux** clients |
+| U-02 | 🟠 | P2-11 | ⬜ ouvert | Écrans Prep monolithiques (Curation ~3 800 l., Metadata ~3 200 l.) |
+| U-03 | 🟡 | P2-11 | ⬜ ouvert | `tauri-app` : 0 test pour 8 112 l. TS |
+| U-04 | 🟡 | P2-12 | ⬜ ouvert | Signalisation de statut fragmentée entre READMEs |
+| U-05 | 🟡 | — | ⬜ ouvert | i18n absent (chaînes FR en dur) — non bloquant |
+| D-01 | 🟠 | P1-7 | ⬜ ouvert | ROADMAP/BACKLOG figés au 20-21 avril (dérive ~29 j) |
+| D-02 | 🟠 | P1-7 | ⬜ ouvert | CHANGELOG 1 942 lignes sans archivage |
+| D-03 | 🟠 | P2-10 | ⬜ ouvert | 267 artefacts trackés sans index (`audit/`, `artifacts/`) |
+| D-05 | 🟡 | P2-12 | ⬜ ouvert | Aucun guide utilisateur final |
+| D-06 | 🟡 | P1-7 | ⬜ ouvert | `API_VERSION` (1.6.23) vs `CONTRACT_VERSION` (1.6.27) — distinction non documentée |
+| N-01 | 🟠 | P0-2 | ⬜ ouvert | Dependabot ne couvre que `github-actions` (npm/pip/cargo absents) |
+| N-04 | 🟡 | P2-14 | 🔵 connu/assumé | Resegmentation écrase `text_raw` + supprime les liens (dette HANDOFF) ; à arbitrer en ADR |
+| N-06 | 🟡 | P2-9 | ⬜ ouvert | `tauri-fixture` sans lockfiles ; CI en `npm install` |
+| N-08 | 🟢 | — | ⬜ ouvert | Divers mineurs (sémantique reflag cible, lock télémétrie Windows, release-gate 3.12, etc.) |
+
+---
+
+## Audits antérieurs — échantillon vérifié (pas un ré-audit exhaustif)
+
+Statuts repris du §7 « Suivi des audits précédents » de `AUDIT_2026-06-12.md`
+(échantillon contre-vérifié en passe 2). Pour le détail finding-par-finding des
+33 findings de 2026-04-19, voir le CHANGELOG (sens commit→finding) et le fichier
+d'audit correspondant.
+
+| Finding | Audit | Statut | Preuve / commit |
+|---------|-------|--------|-----------------|
+| B7 — XSS `innerHTML` ActionsScreen | 2026-04-19 | ✅ corrigé | `td.textContent` (`ActionsScreen.ts`), commit `84e92be`, CHANGELOG « C-08→C-13 » |
+| B6 — rollback import | 2026-04-19 | ✅ corrigé | ADR-040, try/except/rollback dans les importers |
+| C-01 (AGRAFES-3) — lecture fichier arbitraire côté Rust | 2026-04-19 | ✅ corrigé | `read_sidecar_portfile` whitelisté, commit `0c4dc78` |
+| Bloc C-01→C-13 / M-01→M-15 / F-01→F-05 / D-09 (33 findings) | 2026-04-19 | 🔎 voir CHANGELOG | « 33 findings résolus (v0.1.31) » (ROADMAP) — statut individuel à tracer ici au besoin |
+| M-01 — zéro test frontend | 2026-03-26 | 🟦 partiel | 18 fichiers Vitest (Prep) ; reste ouvert pour `tauri-app` (→ U-03 2026-06-12) |
+| W-01 / W-02 — monolithes | 2026-03-26 | 🟦 partiel | Extractions côté Prep faites ; `sidecar.py` + écrans géants demeurent (→ A-01, U-02) |
+| F-03 — épinglage GitHub Actions par SHA | 2026-04-19 | ⬜ ouvert | Non traité (F-04 permissions ✅) — cf. ROADMAP « Next » |

--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -28,6 +28,10 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | N-03 | 🟡 | P1-5 | ✅ corrigé | `links_created` via `cur.rowcount` aux 4 stratégies d'alignement (était `len(links)`). `ae78207`, test `test_alignment.py::test_align_links_created_excludes_ignored_duplicates` |
 | N-05 | 🟡 | P1-5 | 📝 documenté | Race statut de job au shutdown : commentaire `sidecar_jobs.py` (~ligne 152). Fix fidèle = signal de commit côté runner, hors périmètre. `ae78207` |
 | N-07 | 🟡 | P1-5 | ✅ corrigé | `bump_version.py` met à jour le `Cargo.toml` du shell (regex ancrée) + resync `0.1.28 → 0.2.6`. `ae78207` |
+| Q-01 | 🟠 | P0-2 | ✅ corrigé | `[tool.ruff]` (E4/E7/E9/F, E741 ignoré) + job CI `lint` ; 57 violations résorbées (46 autofix, 5 vars, 1 dead). `1b12520` |
+| T-01 | 🔴 | P0-2 | ✅ corrigé | Gate `--cov-fail-under=35` (plancher prouvé, à ratcheter) dans le step pytest CI. `1b12520` |
+| N-01 | 🟠 | P0-2 | ✅ corrigé | `dependabot.yml` étendu à pip/npm/cargo (4 apps + `src-tauri`), groupé hebdo. `1b12520` |
+| — | — | — | ✅ bonus | CI déclenchée aussi sur `development` (les gates ne tiraient que sur `main`). `1b12520` |
 | D-04 | 🟡 | P1-7 | ✅ corrigé | **Ce fichier** (vue inverse finding→statut→commit) |
 | A-05 | — | — | ❌ retiré | Réfuté en passe 2 : les index secondaires existent (`003_alignment.sql`, `012_tokens.sql`) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ txt = [
 dev = [
     "pytest>=7.4",
     "pytest-cov>=4.1",
+    "ruff>=0.14,<0.15",         # lint gate (CI) — see [tool.ruff]
     "charset-normalizer>=3.0",  # CI: avoid encoding fallback to cp1252 on UTF-8 fixtures
 ]
 packaging = [
@@ -47,3 +48,24 @@ where = ["src"]
 testpaths = ["tests"]
 addopts = "-v"
 pythonpath = ["src"]
+
+# ── Lint (audit Q-01) ────────────────────────────────────────────────────────
+# Conservative, high-signal set: ruff defaults (pyflakes F + a slice of
+# pycodestyle E4/E7/E9 — import/statement/syntax errors). Style-only noise is
+# left out for now; widen toward I (imports), B, UP as the codebase is cleaned.
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+ignore = ["E741"]  # ambiguous single-letter names — style, not a bug class here
+
+# ── Coverage (audit T-01) ────────────────────────────────────────────────────
+# CI runs: pytest --cov=src/multicorpus_engine --cov-fail-under=35
+# 35 is a *proven lower bound* (the non-sidecar suite alone hits 36%; the full CI
+# suite is higher since sidecar.py is only exercised by the sidecar tests). Raise
+# it toward (observed CI coverage − 2) after the first gated CI run. The threshold
+# lives in CI, not here, so local `pytest --cov` on a subset never trips the floor.
+[tool.coverage.run]
+source = ["src/multicorpus_engine"]
+branch = false

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -15,7 +15,9 @@ Fichiers mis à jour :
 
     Shell (--shell) :
         tauri-shell/src-tauri/tauri.conf.json   "version": "X.Y.Z"
+        tauri-shell/src-tauri/Cargo.toml        version = "X.Y.Z"
         tauri-shell/src/shell.ts                let APP_VERSION = "X.Y.Z"
+        tauri-shell/package.json                "version": "X.Y.Z"
 """
 
 import argparse
@@ -62,6 +64,15 @@ def bump_shell(version: str, dry_run: bool) -> None:
         ROOT / "tauri-shell/src-tauri/tauri.conf.json",
         r'"version": "[^"]+"',
         f'"version": "{version}"',
+        dry_run,
+    )
+    # Cargo.toml [package] version — anchored at line start so it never touches
+    # dependency `version` keys (those are `name = { version = ... }`). Was drifted
+    # historically (bump_version oubliait Cargo.toml → audit N-07, 2026-06-12).
+    _replace(
+        ROOT / "tauri-shell/src-tauri/Cargo.toml",
+        r'(?m)^version = "[^"]+"',
+        f'version = "{version}"',
         dry_run,
     )
     _replace(

--- a/src/multicorpus_engine/aligner.py
+++ b/src/multicorpus_engine/aligner.py
@@ -277,7 +277,7 @@ def align_pair(
             )
 
     try:
-        conn.executemany(
+        cur = conn.executemany(
             """
             INSERT OR IGNORE INTO alignment_links
                 (run_id, pivot_unit_id, target_unit_id, external_id,
@@ -291,7 +291,10 @@ def align_pair(
         conn.rollback()
         raise
 
-    report.links_created = len(links)
+    # INSERT OR IGNORE silently drops duplicate (pivot,target) pairs; count the
+    # rows actually inserted, not the candidates, so a re-align without purge
+    # does not report phantom links (and links_skipped stays consistent).
+    report.links_created = max(int(cur.rowcount or 0), 0) if links else 0
     if protected_skipped:
         msg = f"{protected_skipped} lien(s) protÃ©gÃ©(s) ignorÃ©(s) pendant l'alignement"
         report.warnings.append(msg)
@@ -482,7 +485,7 @@ def align_pair_external_id_then_position(
 
     if links:
         try:
-            conn.executemany(
+            cur = conn.executemany(
                 """
                 INSERT OR IGNORE INTO alignment_links
                     (run_id, pivot_unit_id, target_unit_id, external_id,
@@ -505,7 +508,10 @@ def align_pair_external_id_then_position(
         report.warnings.append(msg)
         log.info(msg)
 
-    report.links_created = len(links)
+    # INSERT OR IGNORE silently drops duplicate (pivot,target) pairs; count the
+    # rows actually inserted, not the candidates, so a re-align without purge
+    # does not report phantom links (and links_skipped stays consistent).
+    report.links_created = max(int(cur.rowcount or 0), 0) if links else 0
     if debug:
         report.debug = {
             "strategy": "external_id_then_position",
@@ -657,7 +663,7 @@ def align_pair_by_position(
             )
 
     try:
-        conn.executemany(
+        cur = conn.executemany(
             """
             INSERT OR IGNORE INTO alignment_links
                 (run_id, pivot_unit_id, target_unit_id, external_id,
@@ -671,7 +677,10 @@ def align_pair_by_position(
         conn.rollback()
         raise
 
-    report.links_created = len(links)
+    # INSERT OR IGNORE silently drops duplicate (pivot,target) pairs; count the
+    # rows actually inserted, not the candidates, so a re-align without purge
+    # does not report phantom links (and links_skipped stays consistent).
+    report.links_created = max(int(cur.rowcount or 0), 0) if links else 0
     if protected_skipped:
         msg = f"{protected_skipped} lien(s) protÃ©gÃ©(s) ignorÃ©(s) pendant l'alignement"
         report.warnings.append(msg)
@@ -863,7 +872,7 @@ def align_pair_by_similarity(
 
     if links:
         try:
-            conn.executemany(
+            cur = conn.executemany(
                 """
                 INSERT OR IGNORE INTO alignment_links
                     (run_id, pivot_unit_id, target_unit_id, external_id,
@@ -877,7 +886,10 @@ def align_pair_by_similarity(
             conn.rollback()
             raise
 
-    report.links_created = len(links)
+    # INSERT OR IGNORE silently drops duplicate (pivot,target) pairs; count the
+    # rows actually inserted, not the candidates, so a re-align without purge
+    # does not report phantom links (and links_skipped stays consistent).
+    report.links_created = max(int(cur.rowcount or 0), 0) if links else 0
     if report.missing_in_target:
         msg = (
             f"{len(report.missing_in_target)} pivot unit(s) unmatched"

--- a/src/multicorpus_engine/aligner.py
+++ b/src/multicorpus_engine/aligner.py
@@ -9,7 +9,6 @@ Charter section 9: align_by_external_id.
 
 from __future__ import annotations
 
-import json
 import logging
 import sqlite3
 from dataclasses import dataclass, field

--- a/src/multicorpus_engine/cli.py
+++ b/src/multicorpus_engine/cli.py
@@ -793,7 +793,6 @@ def cmd_validate_tei(args: argparse.Namespace) -> None:
     """Validate a TEI XML file or publication package ZIP for xml:id referential integrity."""
     from .utils.tei_validate import validate_tei_ids, validate_tei_package, summarize_tei_validation
     from .runs import utcnow_iso
-    import json as _json
 
     if getattr(args, "path", None):
         path = Path(args.path).resolve()

--- a/src/multicorpus_engine/curation.py
+++ b/src/multicorpus_engine/curation.py
@@ -24,7 +24,6 @@ scripts/validate_regex_migration.py used before this migration.
 
 from __future__ import annotations
 
-import json
 import logging
 import sqlite3
 from dataclasses import dataclass, field

--- a/src/multicorpus_engine/exporters/html_export.py
+++ b/src/multicorpus_engine/exporters/html_export.py
@@ -7,7 +7,6 @@ All dynamic content is escaped via html.escape() — no XSS risk.
 from __future__ import annotations
 
 import html
-import json
 from pathlib import Path
 
 

--- a/src/multicorpus_engine/importers/txt.py
+++ b/src/multicorpus_engine/importers/txt.py
@@ -19,7 +19,6 @@ import json
 import logging
 import re
 import sqlite3
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 

--- a/src/multicorpus_engine/qa_report.py
+++ b/src/multicorpus_engine/qa_report.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import re
 import sqlite3
-import unicodedata
 from pathlib import Path
 from typing import Optional
 

--- a/src/multicorpus_engine/sidecar.py
+++ b/src/multicorpus_engine/sidecar.py
@@ -523,7 +523,7 @@ class _CorpusHandler(BaseHTTPRequestHandler):
         return True
 
     def _create_run(self, kind: str, params: dict, run_id: str | None = None) -> str:
-        from multicorpus_engine.runs import RunIdConflictError, create_run
+        from multicorpus_engine.runs import create_run
 
         return create_run(self._conn(), kind, params, run_id=run_id)
 
@@ -2452,7 +2452,6 @@ class _CorpusHandler(BaseHTTPRequestHandler):
                          odt_numbered_lines, odt_paragraphs, tei.
         """
         import re as _re
-        from pathlib import Path as _Path
         from multicorpus_engine.unicode_policy import normalize as _norm
 
         _NUMBERED_RE = _re.compile(r"^\[\s*(\d+)\s*\]\s*(.+)$", _re.DOTALL)
@@ -8755,7 +8754,6 @@ class _CorpusHandler(BaseHTTPRequestHandler):
         1. external_id match between pivot and target units → score=1.0
         2. Neighbours ±window from anchor (current target or pivot ext_id) → score 1/(1+Δ)
         """
-        import json as _json
 
         pivot_unit_id = body.get("pivot_unit_id")
         target_doc_id = body.get("target_doc_id")

--- a/src/multicorpus_engine/sidecar_jobs.py
+++ b/src/multicorpus_engine/sidecar_jobs.py
@@ -150,6 +150,12 @@ class JobManager:
             with self._lock:
                 job = self._jobs[job_id]
                 if job.status == "canceled":
+                    # Known limitation (audit N-05, 2026-06-12): if a shutdown
+                    # cancel_all() lands AFTER the runner committed but BEFORE this
+                    # block, the job is reported "canceled" while its effects are
+                    # already in the DB. Data stays consistent; only the status
+                    # label is wrong. A faithful fix needs the runner to signal
+                    # whether it committed — out of scope for a targeted patch.
                     return  # don't overwrite a cancel that arrived during execution
                 job.status = "done"
                 job.progress_pct = 100

--- a/src/multicorpus_engine/stats.py
+++ b/src/multicorpus_engine/stats.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import re
 import sqlite3
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Optional
 
 _WORD_RE = re.compile(r"[^\W\d_]+", re.UNICODE)

--- a/src/multicorpus_engine/token_query.py
+++ b/src/multicorpus_engine/token_query.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 import re
 import sqlite3
 
-from .cql_parser import CqlQuery, CqlTokenSpec, parse_cql_query
+from .cql_parser import CqlQuery, parse_cql_query
 
 
 @dataclass(frozen=True)

--- a/src/multicorpus_engine/undo.py
+++ b/src/multicorpus_engine/undo.py
@@ -220,7 +220,12 @@ def _undo_merge_units(
             kept_uid,
         ),
     )
-    return {"units_restored": 2, "alignments_reflagged": 0, "fts_stale": True}
+    # The kept unit's text reverted and the deleted unit was re-created. Any
+    # alignment_links still pointing at them (e.g. created by a re-align run
+    # between the merge and this undo) must be flagged as stale. In the common
+    # case the forward merge already deleted those links, so this is a no-op.
+    reflagged = _reflag_alignment_links(conn, [kept_uid, deleted_uid])
+    return {"units_restored": 2, "alignments_reflagged": reflagged, "fts_stale": True}
 
 
 def _undo_split_unit(
@@ -257,6 +262,14 @@ def _undo_split_unit(
             split_uid,
         ),
     )
+    # The created unit may have acquired alignment_links if a re-align ran
+    # between the split and this undo. alignment_links has no ON DELETE CASCADE
+    # and FKs are enforced, so the unit DELETE below would raise an
+    # IntegrityError; clear its links first, exactly as the forward split does.
+    conn.execute(
+        "DELETE FROM alignment_links WHERE pivot_unit_id=? OR target_unit_id=?",
+        (created_uid, created_uid),
+    )
     # Delete the unit created by the split (was inserted at split_n+1).
     conn.execute("DELETE FROM units WHERE unit_id=?", (created_uid,))
     # Shift everything with n >= split_n + 2 down by 1 to close the gap.
@@ -264,7 +277,9 @@ def _undo_split_unit(
         "UPDATE units SET n = n - 1 WHERE doc_id=? AND n >= ?",
         (doc_id, split_n + 2),
     )
-    return {"units_restored": 1, "alignments_reflagged": 0, "fts_stale": True}
+    # The restored unit's text reverted; flag any links still pointing at it.
+    reflagged = _reflag_alignment_links(conn, [split_uid])
+    return {"units_restored": 1, "alignments_reflagged": reflagged, "fts_stale": True}
 
 
 def _undo_resegment(
@@ -283,6 +298,16 @@ def _undo_resegment(
     if created:
         ph = ",".join("?" * len(created))
         ids = [int(c["unit_id"]) for c in created]
+        # The created units may carry alignment_links from a re-align run after
+        # the resegment (reseg → align → undo reseg). alignment_links has no
+        # ON DELETE CASCADE and FKs are enforced, so clear them before the unit
+        # DELETE to avoid an IntegrityError — same guard as _undo_split_unit
+        # (audit N-02, 2026-06-12).
+        conn.execute(
+            f"DELETE FROM alignment_links"
+            f" WHERE pivot_unit_id IN ({ph}) OR target_unit_id IN ({ph})",
+            ids + ids,
+        )
         conn.execute(
             f"DELETE FROM units WHERE unit_id IN ({ph})",
             ids,

--- a/src/multicorpus_engine/utils/tei_validate.py
+++ b/src/multicorpus_engine/utils/tei_validate.py
@@ -180,7 +180,6 @@ def validate_tei_ids(
             }
     """
     path = Path(path)
-    errors: list[dict] = []
 
     try:
         tree = ET.parse(str(path))

--- a/tauri-prep/eslint.config.mjs
+++ b/tauri-prep/eslint.config.mjs
@@ -1,0 +1,38 @@
+// Surgical ESLint config (audit S-03): enforce no-unsanitized on innerHTML/
+// outerHTML/insertAdjacentHTML to prevent XSS-regression. Intentionally scoped
+// to the no-unsanitized rules only — this is a security gate, not a style suite.
+//
+// `escape.methods` lists the project's verified HTML escapers (each replaces
+// & < > "). A `${escHtml(x)}` substitution is therefore treated as safe; a raw
+// `${x}` is still flagged. Keep this list in sync with the real escapers and
+// never add a function that does not escape.
+import tseslint from 'typescript-eslint';
+import nounsanitized from 'eslint-plugin-no-unsanitized';
+
+const escape = {
+  // Trusted sink (audit S-03): innerHTML is written only via setHtml()/appendHtml()
+  // in lib/safeHtml.ts, which accept a TrustedHtml produced by the safeHtml``
+  // tagged template (auto-escapes) or raw() (explicit vouch). Those sinks carry
+  // the only disables. The methods below keep LEGACY `${escHtml(x)}` template
+  // assignments valid (not yet migrated) — all are verified HTML escapers ...
+  methods: [
+    'escHtml', '_escHtml', 'esc', '_esc', '_escHtmlApp', '_escHtmlMeta',
+    // ... and verified safe renderers whose output is escaped HTML:
+    //   richTextToHtml  — text_raw is XML-escaped at import; fallback via _esc
+    //   highlightChanges[WordLevel] — every char via renderSpecialChars(escHtml())
+    'richTextToHtml', 'highlightChanges', 'highlightChangesWordLevel',
+  ],
+};
+
+export default tseslint.config(
+  { ignores: ['dist/**', 'node_modules/**', '**/*.d.ts', 'scripts/**'] },
+  {
+    files: ['src/**/*.ts'],
+    plugins: { 'no-unsanitized': nounsanitized },
+    languageOptions: { parser: tseslint.parser },
+    rules: {
+      'no-unsanitized/method': ['error', { escape }],
+      'no-unsanitized/property': ['error', { escape }],
+    },
+  },
+);

--- a/tauri-prep/package-lock.json
+++ b/tauri-prep/package-lock.json
@@ -17,7 +17,11 @@
       "devDependencies": {
         "@tauri-apps/cli": "^2.0.0",
         "@vitest/coverage-v8": "^4.1.4",
+        "eslint": "^10.5.0",
+        "eslint-plugin-no-unsanitized": "^4.1.5",
+        "globals": "^17.6.0",
         "typescript": "^5.4.0",
+        "typescript-eslint": "^8.61.1",
         "vite": "^5.2.0",
         "vitest": "^4.1.4"
       }
@@ -405,24 +409,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -440,24 +426,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -473,24 +441,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -559,6 +509,179 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1531,12 +1654,256 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.61.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.4",
@@ -1655,6 +2022,46 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1677,6 +2084,29 @@
         "js-tokens": "^10.0.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1691,6 +2121,46 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1750,6 +2220,174 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-no-unsanitized": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz",
+      "integrity": "sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1758,6 +2396,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -1769,6 +2417,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1788,6 +2457,57 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1801,6 +2521,32 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/has-flag": {
@@ -1819,6 +2565,56 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -1865,6 +2661,51 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2127,6 +2968,22 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2165,6 +3022,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2184,6 +3064,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2194,6 +3081,76 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2249,6 +3206,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/rolldown": {
@@ -2343,6 +3320,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2431,6 +3431,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2438,6 +3451,19 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -2451,6 +3477,40 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -2603,420 +3663,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
@@ -3042,50 +3688,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/vite": {
@@ -3166,6 +3768,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3181,6 +3799,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/tauri-prep/package.json
+++ b/tauri-prep/package.json
@@ -22,7 +22,11 @@
   "devDependencies": {
     "@tauri-apps/cli": "^2.0.0",
     "@vitest/coverage-v8": "^4.1.4",
+    "eslint": "^10.5.0",
+    "eslint-plugin-no-unsanitized": "^4.1.5",
+    "globals": "^17.6.0",
     "typescript": "^5.4.0",
+    "typescript-eslint": "^8.61.1",
     "vite": "^5.2.0",
     "vitest": "^4.1.4"
   }

--- a/tauri-prep/src/components/JobCenter.ts
+++ b/tauri-prep/src/components/JobCenter.ts
@@ -8,6 +8,7 @@
 
 import type { Conn, JobRecord } from "../lib/sidecarClient.ts";
 import { getJob, cancelJob as apiCancelJob } from "../lib/sidecarClient.ts";
+import { raw, setHtml } from "../lib/safeHtml.ts";
 
 type DoneCallback = (job: JobRecord) => void;
 
@@ -213,7 +214,7 @@ export class JobCenter {
     }
 
     html += `</div>`;
-    this._panelEl.innerHTML = html;
+    setHtml(this._panelEl, raw(html));  // built above; all dynamic parts via _esc
 
     this._panelEl.querySelectorAll<HTMLButtonElement>(".jc-cancel-btn").forEach(btn => {
       btn.addEventListener("click", () => { void this._doCancel(btn.dataset.id!); });

--- a/tauri-prep/src/lib/__tests__/safeHtml.test.ts
+++ b/tauri-prep/src/lib/__tests__/safeHtml.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { safeHtml, raw, TrustedHtml } from "../safeHtml.ts";
+
+describe("safeHtml — safeHtml`` tagged template (audit S-03)", () => {
+  it("escapes interpolated text (& < > \" ')", () => {
+    const evil = `<img src=x onerror="alert('xss')">&'`;
+    const out = String(safeHtml`<p>${evil}</p>`);
+    expect(out).toBe(
+      `<p>&lt;img src=x onerror=&quot;alert(&#39;xss&#39;)&quot;&gt;&amp;&#39;</p>`,
+    );
+    expect(out).not.toContain("<img");
+  });
+
+  it("keeps static parts verbatim", () => {
+    expect(String(safeHtml`<div class="x">hi</div>`)).toBe(`<div class="x">hi</div>`);
+  });
+
+  it("does NOT re-escape raw() / nested safeHtml`` fragments", () => {
+    const child = safeHtml`<b>${"a&b"}</b>`;
+    expect(String(safeHtml`<div>${child}</div>`)).toBe(`<div><b>a&amp;b</b></div>`);
+    expect(String(safeHtml`<div>${raw("<hr>")}</div>`)).toBe(`<div><hr></div>`);
+  });
+
+  it("flattens arrays, escaping each item unless raw", () => {
+    const rows = ["a<", "b>"];
+    expect(String(safeHtml`<ul>${rows.map((r) => safeHtml`<li>${r}</li>`)}</ul>`)).toBe(
+      `<ul><li>a&lt;</li><li>b&gt;</li></ul>`,
+    );
+  });
+
+  it("renders null/undefined as empty string", () => {
+    expect(String(safeHtml`<p>${null}${undefined}</p>`)).toBe(`<p></p>`);
+  });
+
+  it("coerces numbers (innerHTML setter calls toString)", () => {
+    expect(String(safeHtml`<span>${42}</span>`)).toBe(`<span>42</span>`);
+  });
+
+  it("raw() is idempotent on TrustedHtml", () => {
+    const t = new TrustedHtml("<x>");
+    expect(raw(t)).toBe(t);
+  });
+});

--- a/tauri-prep/src/lib/inlineConfirm.ts
+++ b/tauri-prep/src/lib/inlineConfirm.ts
@@ -6,9 +6,7 @@
  * Focus automatique sur le bouton Confirmer.
  */
 
-function _esc(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
+import { safeHtml, raw, setHtml } from "./safeHtml.ts";
 
 /**
  * Affiche un banner de confirmation inline dans `container`.
@@ -35,21 +33,21 @@ export function inlineConfirm(
     const savedDisplay = container.style.display;
 
     const restore = (answer: boolean) => {
-      container.innerHTML    = original;
+      setHtml(container, raw(original));  // restore previously-captured DOM
       container.style.display = savedDisplay;
       resolve(answer);
     };
 
     container.style.display = "";
-    container.innerHTML = `
-      <span class="inline-confirm-msg">${_esc(message)}</span>
+    setHtml(container, safeHtml`
+      <span class="inline-confirm-msg">${message}</span>
       <button class="btn btn-sm ${danger ? "btn-danger" : "btn-primary"}" data-inline-ok>
-        ${_esc(confirmLabel)}
+        ${confirmLabel}
       </button>
       <button class="btn btn-sm btn-ghost" data-inline-cancel>
-        ${_esc(cancelLabel)}
+        ${cancelLabel}
       </button>
-    `;
+    `);
 
     const okBtn     = container.querySelector<HTMLButtonElement>("[data-inline-ok]")!;
     const cancelBtn = container.querySelector<HTMLButtonElement>("[data-inline-cancel]")!;

--- a/tauri-prep/src/lib/modalConfirm.ts
+++ b/tauri-prep/src/lib/modalConfirm.ts
@@ -15,6 +15,8 @@
  * cancelled (via button, Escape, or backdrop click).
  */
 
+import { safeHtml, raw, setHtml } from "./safeHtml.ts";
+
 function _esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
@@ -45,14 +47,14 @@ export function modalConfirm(opts: {
     const danger = opts.danger !== false;
     const confirmCls = danger ? "btn-danger" : "btn-primary";
 
-    dialog.innerHTML = `
-      ${titleHtml}
-      <div class="prep-modal-confirm-body">${bodyHtml}</div>
+    setHtml(dialog, safeHtml`
+      ${raw(titleHtml)}
+      <div class="prep-modal-confirm-body">${raw(bodyHtml)}</div>
       <div class="prep-modal-confirm-actions">
-        <button class="btn btn-ghost btn-sm" data-mc-cancel>${_esc(opts.cancelLabel ?? "Annuler")}</button>
-        <button class="btn ${confirmCls} btn-sm" data-mc-ok>${_esc(opts.confirmLabel ?? "Confirmer")}</button>
+        <button class="btn btn-ghost btn-sm" data-mc-cancel>${opts.cancelLabel ?? "Annuler"}</button>
+        <button class="btn ${confirmCls} btn-sm" data-mc-ok>${opts.confirmLabel ?? "Confirmer"}</button>
       </div>
-    `;
+    `);
     overlay.appendChild(dialog);
     document.body.appendChild(overlay);
 

--- a/tauri-prep/src/lib/safeHtml.ts
+++ b/tauri-prep/src/lib/safeHtml.ts
@@ -1,0 +1,64 @@
+// Trusted HTML sink (audit S-03).
+//
+// `safeHtml` is a tagged template that auto-escapes every interpolated value, so
+//   el.innerHTML = safeHtml`<b>${userInput}</b>`
+// is XSS-safe by construction. Pre-built HTML fragments (already escaped, e.g.
+// the output of another safeHtml`` call, a .map(...=>safeHtml``) array, or a
+// verified renderer) must be wrapped in `raw()` to opt out of escaping.
+// (Named `safeHtml`, not `html`, because many screens use a local `html` var.)
+//
+// The eslint-plugin-no-unsanitized config trusts the `safeHtml` tag, so any
+// innerHTML/outerHTML assignment that does NOT go through it is flagged.
+// Escaping parity with the legacy escHtml() helper (& < > ") plus ' for safety.
+
+/** Opaque wrapper marking a string as already-safe HTML (skips escaping). */
+export class TrustedHtml {
+  constructor(readonly value: string) {}
+  toString(): string {
+    return this.value;
+  }
+}
+
+/** Mark an already-safe HTML string so html`` will not re-escape it. */
+export function raw(htmlString: string | TrustedHtml): TrustedHtml {
+  return htmlString instanceof TrustedHtml ? htmlString : new TrustedHtml(htmlString);
+}
+
+function escapeValue(v: unknown): string {
+  if (v instanceof TrustedHtml) return v.value;
+  if (v == null) return "";
+  if (Array.isArray(v)) return v.map(escapeValue).join("");
+  return String(v)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Tagged template producing a TrustedHtml. Static parts are kept verbatim;
+ * every ${interpolation} is escaped unless it is a TrustedHtml (via raw() or a
+ * nested html``). Arrays are flattened (each item escaped/raw individually).
+ */
+export function safeHtml(strings: TemplateStringsArray, ...values: unknown[]): TrustedHtml {
+  let out = strings[0];
+  for (let i = 0; i < values.length; i++) {
+    out += escapeValue(values[i]) + strings[i + 1];
+  }
+  return new TrustedHtml(out);
+}
+
+// The two sanctioned innerHTML sinks. They accept ONLY a TrustedHtml, so the
+// type system guarantees the value came from safeHtml`` (escaped) or raw()
+// (explicit vouch) — a raw string cannot be passed. These are the single place
+// innerHTML is written, hence the lone disables.
+export function setHtml(el: { innerHTML: string }, html: TrustedHtml): void {
+  // eslint-disable-next-line no-unsanitized/property -- sole audited sink; arg is TrustedHtml
+  el.innerHTML = html.value;
+}
+
+export function appendHtml(el: { innerHTML: string }, html: TrustedHtml): void {
+  // eslint-disable-next-line no-unsanitized/property -- sole audited sink; arg is TrustedHtml
+  el.innerHTML += html.value;
+}

--- a/tauri-shell/src-tauri/Cargo.toml
+++ b/tauri-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agrafes-shell"
-version = "0.1.28"
+version = "0.2.6"
 description = "AGRAFES Shell — unified Tauri V0 app (Prep + Concordancier)"
 authors = ["AGRAFES"]
 edition = "2021"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import io
 import sqlite3
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -310,3 +310,36 @@ def test_doc_relations_created(
     assert row["relation_type"] == "translation_of"
     assert row["doc_id"] == bilingual_corpus["en_doc_id"]
     assert row["target_doc_id"] == bilingual_corpus["fr_doc_id"]
+
+
+def test_align_links_created_excludes_ignored_duplicates(
+    db_conn: sqlite3.Connection,
+    bilingual_corpus: dict,
+) -> None:
+    """N-02 audit fix: links_created must count rows actually inserted, not
+    candidates. Re-aligning without purge hits INSERT OR IGNORE (unique index
+    on (pivot_unit_id, target_unit_id)) → 0 real insertions on the second run.
+    """
+    from multicorpus_engine.aligner import align_by_external_id
+
+    first = align_by_external_id(
+        conn=db_conn,
+        pivot_doc_id=bilingual_corpus["fr_doc_id"],
+        target_doc_ids=[bilingual_corpus["en_doc_id"]],
+        run_id="dup-run-a",
+    )[0]
+    assert first.links_created == 3
+
+    # Re-run without purging: every candidate collides → nothing inserted.
+    second = align_by_external_id(
+        conn=db_conn,
+        pivot_doc_id=bilingual_corpus["fr_doc_id"],
+        target_doc_ids=[bilingual_corpus["en_doc_id"]],
+        run_id="dup-run-b",
+    )[0]
+    assert second.links_created == 0
+    # links_skipped is derived from links_created — it must stay consistent.
+    assert second.to_dict()["links_skipped"] == second.pivot_line_count
+
+    total = db_conn.execute("SELECT COUNT(*) FROM alignment_links").fetchone()[0]
+    assert total == 3  # no phantom duplicates were added

--- a/tests/test_analyze_undo_soak.py
+++ b/tests/test_analyze_undo_soak.py
@@ -6,7 +6,6 @@ import importlib.util
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from textwrap import dedent
 
 import pytest
 

--- a/tests/test_contract_docs_sync.py
+++ b/tests/test_contract_docs_sync.py
@@ -14,7 +14,6 @@ import re
 import sys
 from pathlib import Path
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 

--- a/tests/test_contract_openapi_snapshot.py
+++ b/tests/test_contract_openapi_snapshot.py
@@ -21,7 +21,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
 
 # Ensure src is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))

--- a/tests/test_import_conllu.py
+++ b/tests/test_import_conllu.py
@@ -142,7 +142,7 @@ def test_import_conllu_non_numeric_sent_id_falls_back_to_n(
         ),
     )
 
-    report = import_conllu(conn=db_conn, path=conllu, language="en")
+    import_conllu(conn=db_conn, path=conllu, language="en")
 
     rows = db_conn.execute(
         "SELECT external_id, meta_json FROM units ORDER BY n"

--- a/tests/test_metadata_validation.py
+++ b/tests/test_metadata_validation.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-import pytest
 
 _REPO_ROOT = Path(__file__).parent.parent
 _MIGRATIONS_DIR = _REPO_ROOT / "migrations"
 
 
 def _make_conn() -> sqlite3.Connection:
-    from multicorpus_engine.db.connection import get_connection
     from multicorpus_engine.db.migrations import apply_migrations
 
     conn = sqlite3.connect(":memory:")

--- a/tests/test_qa_policy.py
+++ b/tests/test_qa_policy.py
@@ -19,7 +19,6 @@ import json
 import sqlite3
 from pathlib import Path
 
-import pytest
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -240,7 +239,7 @@ def test_write_qa_report_strict_policy(db_conn: sqlite3.Connection, tmp_path: Pa
     from multicorpus_engine.qa_report import write_qa_report
 
     out = tmp_path / "strict_report.json"
-    result = write_qa_report(db_conn, out, fmt="json", policy="strict")
+    write_qa_report(db_conn, out, fmt="json", policy="strict")
     assert out.exists()
     data = json.loads(out.read_text("utf-8"))
     assert data.get("policy_used") == "strict"

--- a/tests/test_qa_report.py
+++ b/tests/test_qa_report.py
@@ -19,7 +19,6 @@ import json
 import sqlite3
 from pathlib import Path
 
-import pytest
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -169,7 +168,8 @@ def test_metadata_readiness_missing_title(db_conn: sqlite3.Connection) -> None:
 def test_gate_status_no_blocking_on_clean_corpus(db_conn: sqlite3.Connection) -> None:
     """A clean doc (title, language, contiguous IDs) should have no blocking issues."""
     from multicorpus_engine.importers.txt import import_txt_numbered_lines
-    import tempfile, os
+    import tempfile
+    import os
 
     with tempfile.NamedTemporaryFile(suffix=".txt", delete=False, mode="w", encoding="utf-8") as f:
         f.write("[1] Bonjour.\n[2] Au revoir.\n")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-import pytest
 
 
 def _setup_corpus(db_conn: sqlite3.Connection, simple_docx: Path) -> None:

--- a/tests/test_regex_boot_audit.py
+++ b/tests/test_regex_boot_audit.py
@@ -20,7 +20,6 @@ import json
 import sqlite3
 from pathlib import Path
 
-import pytest
 
 from multicorpus_engine.regex_boot_audit import (
     PatternAudit,

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -5,7 +5,6 @@ Tests do NOT run npm/pytest/node — only the output-parsing helpers.
 from __future__ import annotations
 
 import importlib.util
-import sys
 from pathlib import Path
 
 # Load release_gate module without executing main()

--- a/tests/test_rich_text.py
+++ b/tests/test_rich_text.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
-import pytest
 
 from multicorpus_engine.importers.rich_text import (
     _NS,

--- a/tests/test_rich_text_roundtrip.py
+++ b/tests/test_rich_text_roundtrip.py
@@ -13,7 +13,6 @@ import sqlite3
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-import pytest
 
 
 _TEI_NS = "http://www.tei-c.org/ns/1.0"

--- a/tests/test_sidecar_conventions.py
+++ b/tests/test_sidecar_conventions.py
@@ -438,7 +438,6 @@ class TestTextStartNIntegration:
 
     def test_segmentation_preserves_paratext(self, cv_sidecar):
         """Resegmentation must not touch units with n < text_start_n."""
-        import sqlite3 as _sqlite3
         base, token, server = cv_sidecar
 
         # Set boundary: n=1,2,3 are paratext
@@ -509,7 +508,7 @@ class TestTextStartNIntegration:
         conn.execute("UPDATE documents SET text_start_n=3 WHERE doc_id=2")
         conn.commit()
 
-        report = align_pair(conn, pivot_doc_id=1, target_doc_id=2, run_id="test-tsn")
+        align_pair(conn, pivot_doc_id=1, target_doc_id=2, run_id="test-tsn")
         conn.commit()
 
         # Check alignment_links — none should reference n=1 or n=2

--- a/tests/test_sidecar_v03.py
+++ b/tests/test_sidecar_v03.py
@@ -119,7 +119,6 @@ def test_curate_preview_returns_stats_and_examples(v03_sidecar) -> None:
 
 def test_curate_preview_does_not_modify_db(v03_sidecar) -> None:
     """Verify that /curate/preview is a pure dry-run — DB units unchanged after preview."""
-    from multicorpus_engine.db.connection import get_connection
 
     base_url = v03_sidecar["base_url"]
     doc_id = v03_sidecar["pivot_doc_id"]

--- a/tests/test_sidecar_v04.py
+++ b/tests/test_sidecar_v04.py
@@ -7,7 +7,6 @@ import json
 import sqlite3
 from pathlib import Path
 from urllib.error import HTTPError
-from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 import pytest

--- a/tests/test_tei_export.py
+++ b/tests/test_tei_export.py
@@ -6,7 +6,6 @@ import sqlite3
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-import pytest
 
 _TEI_NS = "http://www.tei-c.org/ns/1.0"
 _XML_NS = "http://www.w3.org/XML/1998/namespace"
@@ -184,7 +183,8 @@ def _make_aligned_db(db_conn: sqlite3.Connection, tmp_path: Path) -> tuple[int, 
         )
     }
 
-    import datetime, uuid
+    import datetime
+    import uuid
     run_id = str(uuid.uuid4())
     now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     create_run(db_conn, "align", {"mode": "test"}, run_id=run_id)
@@ -240,7 +240,8 @@ def test_tei_export_alignment_status_filter(db_conn: sqlite3.Connection, tmp_pat
     from multicorpus_engine.exporters.tei import export_tei
     from multicorpus_engine.runs import create_run
 
-    import datetime, uuid
+    import datetime
+    import uuid
 
     pivot_txt = tmp_path / "pv2.txt"
     pivot_txt.write_text("[1] Un.\n[2] Deux.\n", encoding="utf-8")
@@ -412,7 +413,8 @@ def test_tei_publication_package_checksums(db_conn: sqlite3.Connection, tmp_path
     """Checksums in the ZIP must match the actual TEI file contents."""
     from multicorpus_engine.importers.txt import import_txt_numbered_lines
     from multicorpus_engine.exporters.tei_package import export_tei_package
-    import hashlib, zipfile
+    import hashlib
+    import zipfile
 
     txt = tmp_path / "chk.txt"
     txt.write_text("[1] Hello.\n", encoding="utf-8")

--- a/tests/test_tei_package_manifest.py
+++ b/tests/test_tei_package_manifest.py
@@ -8,7 +8,6 @@ import sqlite3
 import zipfile
 from pathlib import Path
 
-import pytest
 
 
 def _make_package(db_conn: sqlite3.Connection, tmp_path: Path) -> tuple[Path, dict]:

--- a/tests/test_tei_profile.py
+++ b/tests/test_tei_profile.py
@@ -21,7 +21,6 @@ import zipfile
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-import pytest
 
 
 NS = {"tei": "http://www.tei-c.org/ns/1.0"}
@@ -156,7 +155,8 @@ def test_parcolab_subtitle(db_conn: sqlite3.Connection, tmp_path: Path) -> None:
 def test_package_tei_profile_in_manifest(db_conn: sqlite3.Connection, tmp_path: Path) -> None:
     from multicorpus_engine.exporters.tei_package import export_tei_package
     from multicorpus_engine.importers.txt import import_txt_numbered_lines
-    import os, tempfile
+    import os
+    import tempfile
 
     with tempfile.NamedTemporaryFile(suffix=".txt", delete=False, mode="w", encoding="utf-8") as f:
         f.write("[1] Bonjour.\n[2] Au revoir.\n")

--- a/tests/test_tei_profile_strict.py
+++ b/tests/test_tei_profile_strict.py
@@ -21,7 +21,6 @@ import zipfile
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-import pytest
 
 
 NS = {"tei": "http://www.tei-c.org/ns/1.0"}
@@ -173,7 +172,8 @@ def test_parcolab_like_no_encoding_desc(db_conn: sqlite3.Connection, tmp_path: P
 def test_manifest_includes_validation_summary(db_conn: sqlite3.Connection, tmp_path: Path) -> None:
     from multicorpus_engine.exporters.tei_package import export_tei_package
     from multicorpus_engine.importers.txt import import_txt_numbered_lines
-    import os, tempfile
+    import os
+    import tempfile
 
     with tempfile.NamedTemporaryFile(suffix=".txt", delete=False, mode="w", encoding="utf-8") as f:
         f.write("[1] Bonjour.\n[2] Au revoir.\n")
@@ -201,7 +201,8 @@ def test_manifest_includes_validation_summary(db_conn: sqlite3.Connection, tmp_p
 def test_manifest_validation_summary_counts(db_conn: sqlite3.Connection, tmp_path: Path) -> None:
     """Empty doc title → warning emitted → validation_summary counts it."""
     from multicorpus_engine.exporters.tei_package import export_tei_package
-    import os, tempfile
+    import os
+    import tempfile
 
     with tempfile.NamedTemporaryFile(suffix=".txt", delete=False, mode="w", encoding="utf-8") as f:
         f.write("[1] Bonjour.\n")
@@ -238,7 +239,6 @@ def test_strict_profile_with_strict_policy_gate(db_conn: sqlite3.Connection) -> 
         ("", "fr", "source"),
     )
     db_conn.commit()
-    doc_id = db_conn.execute("SELECT last_insert_rowid()").fetchone()[0]
 
     report_strict = generate_qa_report(db_conn, policy="strict")
     # Empty title → meta_error → blocking in strict

--- a/tests/test_tei_validate.py
+++ b/tests/test_tei_validate.py
@@ -6,7 +6,6 @@ import sqlite3
 import zipfile
 from pathlib import Path
 
-import pytest
 
 from multicorpus_engine.utils.tei_validate import validate_tei_ids, validate_tei_package
 
@@ -229,7 +228,8 @@ def test_validate_tei_package_with_alignment(db_conn: sqlite3.Connection, tmp_pa
     from multicorpus_engine.importers.txt import import_txt_numbered_lines
     from multicorpus_engine.exporters.tei_package import export_tei_package
     from multicorpus_engine.runs import create_run
-    import datetime, uuid
+    import datetime
+    import uuid
 
     pivot_txt = tmp_path / "pv.txt"
     pivot_txt.write_text("[1] Un.\n[2] Deux.\n", encoding="utf-8")

--- a/tests/test_token_collocates.py
+++ b/tests/test_token_collocates.py
@@ -6,7 +6,6 @@ Uses an in-memory SQLite DB seeded with minimal CoNLL-U-style token data
 
 from __future__ import annotations
 
-import math
 import sqlite3
 from pathlib import Path
 
@@ -20,7 +19,6 @@ _MIGRATIONS_DIR = _REPO_ROOT / "migrations"
 
 def _make_conn() -> sqlite3.Connection:
     """Fresh in-memory DB with all migrations applied."""
-    from multicorpus_engine.db.connection import get_connection
     from multicorpus_engine.db.migrations import apply_migrations
 
     conn = sqlite3.connect(":memory:")

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -419,3 +419,258 @@ def test_undo_marks_action_reverted_and_inserts_undo_entry(
     assert history[0]["reverted_by_id"] == payload["undo_action_id"]
     assert history[1]["action_type"] == "undo"
     assert history[1]["reverted"] == 0
+
+
+# ---------------------------------------------------------------------------
+# N-02 (audit 2026-06-12): undo of merge/split must re-flag alignment links
+# that survive the action (e.g. created by a re-align between the action and
+# the undo), because the restored unit's text reverts.
+# ---------------------------------------------------------------------------
+
+
+def _add_link(
+    conn: sqlite3.Connection,
+    pivot_uid: int,
+    target_uid: int,
+    *,
+    pivot_doc: int,
+    target_doc: int,
+    ext_id: int = 1,
+    run_id: str = "rerun",
+) -> None:
+    """Insert an alignment_link with source_changed_at left NULL (not flagged)."""
+    conn.execute(
+        "INSERT INTO alignment_links"
+        " (run_id, pivot_unit_id, target_unit_id, external_id,"
+        "  pivot_doc_id, target_doc_id, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (run_id, pivot_uid, target_uid, ext_id, pivot_doc, target_doc,
+         "2026-06-16T00:00:00Z"),
+    )
+
+
+def test_undo_merge_reflags_links_created_after_merge(
+    db_conn: sqlite3.Connection,
+) -> None:
+    """A link added on the kept unit after the merge must be flagged on undo."""
+    from multicorpus_engine.action_history import (
+        ACTION_MERGE_UNITS,
+        insert_unit_snapshots,
+        record_prep_action,
+    )
+    from multicorpus_engine.undo import execute_undo
+
+    doc_id, _ = _seed_doc(db_conn, ["Phrase un.", "Phrase deux.", "Phrase trois."])
+    tgt_doc, [t1] = _seed_doc(db_conn, ["Target line."])
+
+    n1, n2 = 1, 2
+    row1 = db_conn.execute(
+        "SELECT unit_id, external_id, text_raw, text_norm, unit_role, meta_json"
+        " FROM units WHERE doc_id=? AND n=? AND unit_type='line'", (doc_id, n1),
+    ).fetchone()
+    row2 = db_conn.execute(
+        "SELECT unit_id, external_id, text_raw, text_norm, unit_role, meta_json"
+        " FROM units WHERE doc_id=? AND n=? AND unit_type='line'", (doc_id, n2),
+    ).fetchone()
+    uid1, uid2 = int(row1["unit_id"]), int(row2["unit_id"])
+
+    action_id = record_prep_action(
+        db_conn, doc_id=doc_id, action_type=ACTION_MERGE_UNITS,
+        description=f"Fusion u.{n1} + u.{n2}",
+        context={
+            "merged_unit_ids": [uid1, uid2], "kept_unit_id": uid1,
+            "deleted_unit_id": uid2, "n1": n1, "n2": n2,
+            "kept_external_id_before": row1["external_id"],
+            "deleted_external_id_before": row2["external_id"],
+        },
+    )
+    insert_unit_snapshots(
+        db_conn, action_id,
+        [
+            {"unit_id": uid1, "text_raw_before": row1["text_raw"],
+             "text_norm_before": row1["text_norm"], "unit_role_before": row1["unit_role"],
+             "meta_json_before": row1["meta_json"]},
+            {"unit_id": uid2, "text_raw_before": row2["text_raw"],
+             "text_norm_before": row2["text_norm"], "unit_role_before": row2["unit_role"],
+             "meta_json_before": row2["meta_json"]},
+        ],
+    )
+    # Forward merge (mirrors the handler): deletes both units' links, merges
+    # text into uid1, deletes uid2, renumbers.
+    db_conn.execute(
+        "DELETE FROM alignment_links WHERE pivot_unit_id IN (?,?) OR target_unit_id IN (?,?)",
+        (uid1, uid2, uid1, uid2),
+    )
+    merged_raw = (row1["text_raw"] or "").rstrip() + " " + (row2["text_raw"] or "").lstrip()
+    merged_norm = (row1["text_norm"] or "").rstrip() + " " + (row2["text_norm"] or "").lstrip()
+    db_conn.execute(
+        "UPDATE units SET text_raw=?, text_norm=? WHERE doc_id=? AND n=?",
+        (merged_raw, merged_norm, doc_id, n1),
+    )
+    db_conn.execute("DELETE FROM units WHERE doc_id=? AND n=?", (doc_id, n2))
+    db_conn.execute("UPDATE units SET n = n - 1 WHERE doc_id=? AND n > ?", (doc_id, n2))
+    # Re-align AFTER the merge: a fresh link on the kept (merged) unit.
+    _add_link(db_conn, uid1, t1, pivot_doc=doc_id, target_doc=tgt_doc)
+    db_conn.commit()
+
+    pre = db_conn.execute(
+        "SELECT source_changed_at FROM alignment_links WHERE pivot_unit_id=?", (uid1,),
+    ).fetchone()
+    assert pre["source_changed_at"] is None  # not flagged yet
+
+    payload = execute_undo(db_conn, doc_id)
+    db_conn.commit()
+
+    assert payload["alignments_reflagged"] == 1
+    post = db_conn.execute(
+        "SELECT source_changed_at FROM alignment_links WHERE pivot_unit_id=?", (uid1,),
+    ).fetchone()
+    assert post["source_changed_at"] is not None
+
+
+def test_undo_split_reflags_and_is_fk_safe_after_realign(
+    db_conn: sqlite3.Connection,
+) -> None:
+    """Undo of a split must (a) not FK-fail when the created unit has links,
+    and (b) re-flag links surviving on the restored unit."""
+    from multicorpus_engine.action_history import (
+        ACTION_SPLIT_UNIT,
+        insert_unit_snapshots,
+        record_prep_action,
+    )
+    from multicorpus_engine.undo import execute_undo
+
+    doc_id, _ = _seed_doc(db_conn, ["Phrase A B C.", "Phrase suivante."])
+    tgt_doc, [t1] = _seed_doc(db_conn, ["Target line."])
+    before = _snapshot_units(db_conn, doc_id)
+
+    unit_n, text_a, text_b = 1, "Phrase A", "B C."
+    row = db_conn.execute(
+        "SELECT unit_id, external_id, text_raw, text_norm, unit_role, meta_json"
+        " FROM units WHERE doc_id=? AND n=? AND unit_type='line'", (doc_id, unit_n),
+    ).fetchone()
+    uid = int(row["unit_id"])
+
+    # Forward split (mirrors the handler): delete the unit's links, shift, write
+    # text_a + NULL external_id, insert the new unit at n+1.
+    db_conn.execute(
+        "DELETE FROM alignment_links WHERE pivot_unit_id=? OR target_unit_id=?", (uid, uid),
+    )
+    db_conn.execute("UPDATE units SET n = n + 1 WHERE doc_id=? AND n > ?", (doc_id, unit_n))
+    db_conn.execute(
+        "UPDATE units SET text_raw=?, text_norm=?, external_id=NULL WHERE doc_id=? AND n=?",
+        (text_a, text_a, doc_id, unit_n),
+    )
+    cur = db_conn.execute(
+        "INSERT INTO units (doc_id, unit_type, n, external_id, text_raw, text_norm, meta_json)"
+        " VALUES (?, 'line', ?, NULL, ?, ?, NULL)",
+        (doc_id, unit_n + 1, text_b, text_b),
+    )
+    new_uid = int(cur.lastrowid)
+
+    action_id = record_prep_action(
+        db_conn, doc_id=doc_id, action_type=ACTION_SPLIT_UNIT,
+        description=f"Coupure u.{unit_n}",
+        context={
+            "split_unit_id": uid, "split_unit_n": unit_n,
+            "created_unit_id": new_uid, "created_unit_n": unit_n + 1,
+            "external_id_before": row["external_id"],
+        },
+    )
+    insert_unit_snapshots(
+        db_conn, action_id,
+        [{"unit_id": uid, "text_raw_before": row["text_raw"],
+          "text_norm_before": row["text_norm"], "unit_role_before": row["unit_role"],
+          "meta_json_before": row["meta_json"]}],
+    )
+    # Re-align AFTER the split: links on BOTH the restored unit and the created
+    # one. The link on the created unit is what would FK-fail the unit DELETE.
+    _add_link(db_conn, uid, t1, pivot_doc=doc_id, target_doc=tgt_doc, ext_id=1)
+    _add_link(db_conn, new_uid, t1, pivot_doc=doc_id, target_doc=tgt_doc, ext_id=2)
+    db_conn.commit()
+
+    payload = execute_undo(db_conn, doc_id)  # must not raise IntegrityError
+    db_conn.commit()
+
+    # Restored unit's link re-flagged; created unit's link gone with the unit.
+    assert payload["alignments_reflagged"] == 1
+    flagged = db_conn.execute(
+        "SELECT source_changed_at FROM alignment_links WHERE pivot_unit_id=?", (uid,),
+    ).fetchone()
+    assert flagged is not None and flagged["source_changed_at"] is not None
+    orphan = db_conn.execute(
+        "SELECT COUNT(*) FROM alignment_links WHERE pivot_unit_id=? OR target_unit_id=?",
+        (new_uid, new_uid),
+    ).fetchone()[0]
+    assert orphan == 0
+    assert _snapshot_units(db_conn, doc_id) == before
+
+
+def test_undo_resegment_is_fk_safe_after_realign(
+    db_conn: sqlite3.Connection,
+) -> None:
+    """Undo of a resegment must not FK-fail when a re-align created links on the
+    resegment-created units (reseg → align → undo reseg). Same bug class as the
+    split-undo FK guard; surfaced during the review pass on the N-02 fix.
+    """
+    from multicorpus_engine.action_history import (
+        ACTION_RESEGMENT,
+        insert_unit_snapshots,
+        record_prep_action,
+    )
+    from multicorpus_engine.segmenter import resegment_document
+    from multicorpus_engine.undo import execute_undo
+
+    doc_id, _ = _seed_doc(db_conn, ["Phrase un. Phrase deux.", "Et trois ?"])
+    tgt_doc, [t1] = _seed_doc(db_conn, ["Target line."])
+    before = _snapshot_units(db_conn, doc_id)
+
+    created_ids: list[int] = []
+
+    def recorder(payload):
+        units_before = payload["units_before"]
+        if not units_before:
+            return None
+        created_ids.extend(payload["created_unit_ids"])
+        action_id = record_prep_action(
+            db_conn, doc_id=payload["doc_id"], action_type=ACTION_RESEGMENT,
+            description=f"Reseg {len(units_before)} → {len(payload['created_unit_ids'])}",
+            context={
+                "pack": payload["pack"], "lang": payload["lang"],
+                "text_start_n": payload["text_start_n"],
+                "units_deleted_after_ids": [u["unit_id"] for u in units_before],
+                "units_created_after_json": [
+                    {"unit_id": uid, "n": n}
+                    for uid, n in zip(payload["created_unit_ids"], payload["new_units_n"])
+                ],
+                "units_before": units_before,
+            },
+        )
+        insert_unit_snapshots(
+            db_conn, action_id,
+            [{"unit_id": u["unit_id"], "text_raw_before": u["text_raw"],
+              "text_norm_before": u["text_norm"] or "",
+              "unit_role_before": u["unit_role"], "meta_json_before": u["meta_json"]}
+             for u in units_before],
+        )
+        return action_id
+
+    resegment_document(
+        db_conn, doc_id=doc_id, lang="fr", pack="auto", record_action=recorder,
+    )
+    assert created_ids, "resegment should have created at least one unit"
+
+    # Re-align AFTER the resegment: a link on a resegment-created unit. This is
+    # what would FK-fail the unit DELETE during undo without the guard.
+    _add_link(db_conn, created_ids[0], t1, pivot_doc=doc_id, target_doc=tgt_doc)
+    db_conn.commit()
+
+    execute_undo(db_conn, doc_id)  # must not raise IntegrityError
+    db_conn.commit()
+
+    orphan = db_conn.execute(
+        "SELECT COUNT(*) FROM alignment_links WHERE pivot_unit_id=? OR target_unit_id=?",
+        (created_ids[0], created_ids[0]),
+    ).fetchone()[0]
+    assert orphan == 0
+    assert _snapshot_units(db_conn, doc_id) == before

--- a/tests/test_unicode_policy.py
+++ b/tests/test_unicode_policy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 from multicorpus_engine.unicode_policy import normalize, text_display, count_sep
 
 

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -27,7 +27,6 @@ def test_txt_import_numbered_lines(
 ) -> None:
     """TXT importer must extract [n] lines as line units."""
     from multicorpus_engine.importers.txt import import_txt_numbered_lines
-    from multicorpus_engine.indexer import build_index
 
     path = _write_txt(tmp_path / "doc.txt", [
         "Introduction",


### PR DESCRIPTION
Remédiation de l'audit `docs/AUDIT_2026-06-12.md`. Branche depuis `development`.

## Correctifs métier (vérifiés manuellement dans le code)
- **N-02** — l'undo de merge/split re-flague désormais les `alignment_links` survivants (`source_changed_at`) au lieu d'un `0` en dur ; purge des liens avant le `DELETE` d'unité pour éviter un crash FK (pas de `ON DELETE CASCADE`). Même garde appliquée à `_undo_resegment` (crash FK identique, trouvé en revue).
- **N-03** — `links_created` comptait les candidats, pas les insertions : `len(links)` après `INSERT OR IGNORE` aux **4 stratégies** → corrigé via `cur.rowcount`.
- **N-05** — documenté (pas corrigé) : statut de job trompeur au shutdown (commentaire sur le site).
- **N-07** — `bump_version.py` met à jour le `Cargo.toml` du shell + resync `0.1.28 → 0.2.6`.

## Filet CI (Q-01/T-01/N-01)
- **Q-01** — `[tool.ruff]` + job CI `lint` ; 57 violations résorbées, ruff bloquant et vert.
- **T-01** — gate `--cov-fail-under=35` (plancher prouvé, à ratcheter) dans le step pytest.
- **N-01** — `dependabot.yml` étendu à pip/npm/cargo (4 apps + `src-tauri`), groupé hebdo.
- **Bonus** — la CI se déclenche désormais sur `development` (avant : `main` seulement).

## Traçabilité
- `docs/AUDIT_2026-06-12.md` + `docs/AUDIT_FOLLOW_UP.md` (vue inverse finding → statut → commit, ferme D-04).

## Groundwork S-03 (partiel, volontairement non câblé en CI)
- `tauri-prep/src/lib/safeHtml.ts` : sink HTML type-safe (`setHtml`/`safeHtml\`\``/`raw()`) + 7 tests unitaires + config ESLint `no-unsanitized` ; 3 fichiers migrés. **Pas branché en CI** → zéro impact, c'est une fondation à compléter (92 sites des écrans géants + app/shell restent).

## Vérification
- `ruff` vert ; 418 tests non-sidecar passent ; contrat OpenAPI intact ; `test_sidecar_conventions.py` passe (43) ; les 4 nouveaux tests de régression (N-02 ×3, N-03 ×1) passent.
- ⚠️ **La CI ne tournera pas automatiquement sur cette PR** : le fix des triggers ne prend effet sur `development` qu'après ce merge. Vérification faite en local.

## Suite
La branche `deps/vite8-upgrade` (DEP-1) suit en PR #2 — elle aura la CI gated une fois celle-ci mergée, et résoudra le petit conflit sur `tauri-prep/package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)