### PR TITLE
feat(prep): ShareDocs ingestion P1 — WebDAV + dispatch_import + import-remote CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **prep / ingestion distante WebDAV — `import-remote` (ShareDocs, Phase 1)** : nouvelle sous-commande CLI `multicorpus import-remote --url <dossier-webdav> --mode <mode>` qui parcourt un dossier WebDAV (validé contre ShareDocs Huma-Num — Nextcloud/SabreDAV) et ingère en lot tous les fichiers correspondant au mode (extension dérivée du `--mode`, surchargeable via `--include`). Chaque fichier est téléchargé en temporaire, **dédupliqué par `source_hash`** (les ré-exécutions sont idempotentes), importé via le pipeline existant (1 run/fichier), puis sa provenance `source_path` est fixée à l'URL distante. Les erreurs par fichier sont reportées **sans interrompre le lot** ; garde de taille `--max-file-mb` (200 par défaut). Client WebDAV **stdlib pur** (`urllib` + `defusedxml`, aucune nouvelle dépendance) limité à PROPFIND (Depth:1) + GET ; **TLS toujours vérifié** ; credentials lus uniquement dans l'environnement (`AGRAFES_WEBDAV_TOKEN`, ou `AGRAFES_WEBDAV_USER`/`AGRAFES_WEBDAV_PASSWORD`), **jamais persistés** en db/runs/logs. Refactor préalable : le dispatch `mode → importer` est centralisé dans `importers/dispatch.py` (`dispatch_import`), désormais point unique partagé par `import` et `import-remote`. La db reste strictement locale (pas de partage de db par WebDAV — cf. `docs/DESIGN_sharedocs_ingestion.md`). Phases 2 (endpoints sidecar) et 3 (UI Prep) à suivre. 21 nouveaux tests (client WebDAV + batch).
+
 ---
 
 ## [0.2.6] - 2026-05-19

--- a/docs/DESIGN_sharedocs_ingestion.md
+++ b/docs/DESIGN_sharedocs_ingestion.md
@@ -1,0 +1,200 @@
+# Notes de design — Connecteur d'ingestion ShareDocs (WebDAV)
+
+> Statut : décisions figées, prêtes à transformer en ticket(s).
+> Date : 2026-06-12. Cible : `multicorpus-engine` v0.3.x.
+
+## 1. Cadre & périmètre
+
+**But.** Tirer des documents source depuis un dépôt **ShareDocs Huma-Num**
+(Nextcloud / SabreDAV, WebDAV) pour alimenter la db locale via le pipeline
+d'import existant. C'est de l'**ingestion en entrée** : la db reste strictement
+locale.
+
+**Hors périmètre — décision explicite.** On ne partage **pas** la db SQLite via
+WebDAV. Le plugin Madbot fait du GET/PUT de fichier entier (pas un montage FS) ;
+combiné au mode WAL et à l'absence de `LOCK`, cela donne du *last-writer-wins*
+silencieux et un risque de snapshot incohérent. La collaboration multi-utilisateur
+est un sujet séparé (serveur, ou handoff sérialisé assumé), pas un effet de bord
+de ce connecteur.
+
+**Choix cadrants validés.**
+
+| Axe | Décision | Raison |
+|-----|----------|--------|
+| Dépendances | **stdlib `urllib` uniquement** | Besoin réel = lister + télécharger. Le sidecar fait déjà du HTTP stdlib ([sidecar.py:44-46](../src/multicorpus_engine/sidecar.py#L44)). Pas de `webdav4`/`httpx` dans le bundle PyInstaller. |
+| Périmètre v1 | **CLI + endpoint sidecar + UI Prep** | Couvre aussi les utilisateurs non-CLI. Découpé en 3 phases livrables. |
+| Granularité | **Dossier / batch** | Le vrai gain : pointer un dossier ShareDocs et ingérer tout le corpus d'un coup. |
+| XML | **`defusedxml`** pour parser le PROPFIND | Déjà une dépendance ; protège contre XXE. |
+| Credentials | **Jamais persistés** (db / runs / logs / portfile / télémétrie) | Voir §6. |
+
+## 2. Point d'intégration
+
+`cmd_import` ([cli.py:113](../src/multicorpus_engine/cli.py#L113)) résout `--path`
+vers **un fichier local unique**, puis dispatche par `--mode` vers l'importer, qui
+ouvre le chemin lui-même. Le branchement propre :
+
+1. **Résoudre la source distante → fichier temporaire** avant le dispatch.
+2. **Réutiliser le dispatch existant** sans toucher aux importers.
+3. **Tracer la provenance** : `source_path` = URL distante, `source_hash` = hash
+   des octets téléchargés (identique au cas local, cf. ADR-011).
+
+### Refactor préalable (bloquant)
+
+Extraire le if/elif `mode → importer` ([cli.py:147-237](../src/multicorpus_engine/cli.py#L147))
+dans un helper unique :
+
+```
+multicorpus_engine/importers/dispatch.py
+    dispatch_import(conn, mode, path, *, language, title, doc_role,
+                    resource_type, tei_unit, run_id, run_logger) -> Report
+```
+
+- `cmd_import` se réduit à un appel à ce helper.
+- **Vérifier si `sidecar._handle_import` possède sa propre copie du dispatch** et
+  l'unifier sur le même helper (sinon trois sites à maintenir).
+- Le helper devient le point d'appel commun pour `import`, `import-remote` (CLI) et
+  `POST /import-remote` (sidecar).
+
+## 3. Client WebDAV stdlib
+
+Module : `multicorpus_engine/remote/webdav.py`. Pas de classe lourde : deux
+opérations.
+
+### 3.1 PROPFIND (lister un dossier)
+
+```
+Request(url, method="PROPFIND",
+        headers={"Depth": "1", "Content-Type": "application/xml", **auth},
+        data=PROPFIND_BODY)
+```
+
+- Réponse `207 Multi-Status`, parsée avec **`defusedxml.ElementTree`** (namespace
+  `DAV:`).
+- Par entrée `<d:response>` : `href`, `getcontentlength`, `getlastmodified`,
+  `getcontenttype`, `getetag`, et `resourcetype` (présence de `<d:collection/>` =
+  dossier).
+- **Gotchas tranchés :**
+  - Les `href` sont **percent-encodés** et souvent **absolus côté serveur**
+    (`/remote.php/dav/files/user/...`) → résoudre contre `scheme://host` de l'URL
+    de base ; décoder pour l'affichage, ré-encoder pour les requêtes.
+  - La **première entrée** d'un listing Depth:1 est le dossier lui-même → la
+    sauter (match `href == chemin demandé`).
+  - **`Depth` strictement `"1"`** — jamais `infinity` (pas de listing récursif
+    massif).
+  - Mapping erreurs : `401` → message d'auth clair ; `404` → dossier introuvable ;
+    timeout → message réseau. Pas de stacktrace brute remontée à l'UI.
+
+### 3.2 GET (télécharger)
+
+- `Request(file_url, headers=auth)`, streaming par chunks (4 MiB) vers un fichier
+  temp.
+- **Contrôle d'intégrité = taille seule** (Content-Length vs octets écrits),
+  comme Madbot. Pas d'ETag (opaque, non garanti = hash de contenu).
+- Garde `--max-file-mb` (défaut **200**) : au-delà → skip + report, pas de
+  remplissage disque.
+
+### 3.3 Authentification
+
+- Modes : `basic` (`Authorization: Basic base64(user:pass)`), `bearer`
+  (`Authorization: Bearer <token>`), `anonymous` (aucun header).
+- **TLS vérifié systématiquement.** Pas de `--insecure` en v1 (footgun).
+- Résolution CLI (env) :
+  - `AGRAFES_WEBDAV_TOKEN` présent → `bearer`
+  - sinon `AGRAFES_WEBDAV_USER` + `AGRAFES_WEBDAV_PASSWORD` → `basic`
+  - sinon `anonymous`
+  - `--auth {auto,basic,bearer,anonymous}` peut forcer le mode (`auto` = ci-dessus).
+
+## 4. Flux batch (cœur métier)
+
+1. **PROPFIND** le dossier → entrées.
+2. **Filtre** : garder les fichiers (pas les collections) correspondant à
+   l'extension dérivée du `--mode` (`docx_* → *.docx`, `odt_* → *.odt`,
+   `txt_* → *.txt`, `tei → *.xml`, `conllu → *.conllu`), surchargeable via
+   `--include "<glob>"`. Les non-correspondants → `skipped-filtered` (reporté).
+3. **Dédup** : pour chaque fichier retenu, télécharger → calculer le hash (même
+   helper `_compute_file_hash` que les importers) → si un `documents.source_hash`
+   identique existe déjà, **`skipped-duplicate`** (pas de run vide créé). Aligné
+   sur la sémantique ADR-011.
+4. **Import** : appeler `dispatch_import(...)` sur le fichier temp.
+   - **Un run par fichier** (modèle 1-fichier-1-run inchangé) ; chaque doc reste
+     traçable. Le batch agrège les `run_id`.
+   - **Provenance** : après import, `UPDATE documents SET source_path = <url>
+     WHERE doc_id = <renvoyé>`. Le `source_hash` (octets) reste tel quel. Évite de
+     modifier la signature de chaque importer.
+5. **Robustesse** : une erreur de download ou d'import sur un fichier est
+   **reportée et n'interrompt pas le batch** (continue au suivant).
+6. **Temp** : `tempfile.mkdtemp()` par batch, nettoyé en `finally`
+   (`shutil.rmtree`). **Noms de fichiers temp générés** — ne jamais construire un
+   chemin local à partir du nom serveur (garde contre la traversée de chemin).
+
+### Report batch (JSON, style `_ok`/`_err` existant)
+
+Par fichier : `status` ∈ {`imported`, `skipped-duplicate`, `skipped-filtered`,
+`skipped-oversize`, `error`}, `source_url`, `doc_id`, `run_id`, `source_hash`,
+compteurs (lignes/unités), `error` éventuel. Plus un agrégat (totaux par statut).
+
+## 5. Phasage (livrable incrémental)
+
+**Phase 1 — CLI ✅ LIVRÉ** (branche `feat/sharedocs-ingestion-p1`) **— validable en headless contre ShareDocs.**
+- Refactor `dispatch_import`.
+- `remote/webdav.py` (PROPFIND + GET + auth).
+- Sous-commande `import-remote` :
+  ```
+  multicorpus import-remote --db <db> --url <folder-url> --mode <mode>
+      [--language fr] [--include "*.docx"] [--auth auto]
+      [--doc-role ...] [--resource-type ...] [--max-file-mb 200]
+  ```
+  → report batch JSON.
+
+**Phase 2 — Sidecar.**
+- `POST /webdav/list` (body : url + creds) → listing (name, href, is_dir, size,
+  modified, content_type). **Hors write-lock** (réseau lecture seule), pas de
+  blocage des écritures db.
+- `POST /import-remote` (body : url, mode, language, include, creds, doc_role,
+  resource_type, max_file_mb) → **sous `_track_stage("import-remote")` + write
+  lock** (écrit en db). Progression par fichier via **`JobManager`** (réutilise la
+  mécanique de `POST /import`). Renvoie le report batch.
+- Ajouter les deux routes à la liste autorisée du `do_POST`
+  ([sidecar.py:671](../src/multicorpus_engine/sidecar.py#L671)).
+- `runs.params` ne stocke **que** `url` + `mode` (jamais les creds).
+
+**Phase 3 — UI Prep.**
+- Écran « Importer depuis ShareDocs » :
+  - Formulaire : URL de base, mode d'auth, champs creds.
+  - « Connecter » → `POST /webdav/list` → vue dossier navigable (nom, type,
+    taille, modifié).
+  - Sélection dossier → choix `mode` + `language` + filtre `include` → « Importer ».
+  - `POST /import-remote` → barre de progression (événements `JobManager`) → table
+    de report par fichier.
+  - **Creds : en mémoire pour la session uniquement**, jamais sur disque/db (v1).
+    Re-saisie à la session suivante. Compromis UX assumé ; keychain OS = évolution
+    ultérieure.
+
+## 6. Sécurité (tranché)
+
+- `defusedxml` obligatoire pour le PROPFIND (XXE).
+- TLS vérifié, pas d'opt-out.
+- **Credentials jamais écrits** : db, `runs.params`, logs de run, logs de requête
+  sidecar (exclure les champs auth du body loggé), portfile, événements télémétrie.
+- Creds CLI via env ; creds UI via body POST sur `127.0.0.1` uniquement, en mémoire.
+- Garde traversée de chemin (noms temp générés) ; `Depth: 1` strict ; garde taille.
+
+## 7. Tests
+
+- **Unitaires client WebDAV** : `urlopen` mocké, échantillons XML `207`
+  multistatus (s'inspirer des fixtures `test_canonical` de Madbot). Asserts :
+  parsing entrées, skip du dossier-self, résolution des href, construction header
+  auth (basic/bearer/anon), mapping `401`/`404`/timeout.
+- **Unitaires batch** : dossier mixte (docx/odt/txt/xml + un `.pdf` parasite) →
+  filtre ; `skipped-duplicate` (hash match) ; erreur de download sur un fichier
+  → continue ; `skipped-oversize` ; provenance `source_path == url`.
+- **Intégration (opt-in, gated, skip en CI)** contre ShareDocs Huma-Num, creds via
+  env — calquée sur le test d'intégration gated de Madbot.
+
+## 8. À confirmer au moment du ticket (résiduel)
+
+- Forme exacte des événements de progression `JobManager` (`sidecar_jobs.py`) pour
+  câbler la barre UI — à lire en phase 2/3.
+- Le `Report` de chaque importer expose-t-il bien `doc_id` (pour l'UPDATE
+  `source_path`) ? À vérifier importer par importer.
+- `sidecar._handle_import` duplique-t-il le dispatch ? → à unifier dans le refactor §2.

--- a/docs/TICKET_SHAREDOCS_INGESTION_P1_CLI.md
+++ b/docs/TICKET_SHAREDOCS_INGESTION_P1_CLI.md
@@ -1,0 +1,203 @@
+# Mission : Connecteur d'ingestion ShareDocs — Phase 1 (refactor dispatch + CLI `import-remote`)
+
+Tu interviens sur le repo AGRAFES (branche `development`).
+
+Lis d'abord **[docs/DESIGN_sharedocs_ingestion.md](DESIGN_sharedocs_ingestion.md)**
+(décisions cadres, toutes figées) puis [HANDOFF_PREP.md](../HANDOFF_PREP.md). Ce
+ticket implémente la **Phase 1** du design : la couche WebDAV stdlib + la
+sous-commande CLI batch. **Pas de sidecar, pas d'UI** (phases 2 et 3 séparées).
+
+# Contexte
+
+AGRAFES doit pouvoir tirer des documents source d'un dépôt **ShareDocs Huma-Num**
+(WebDAV : Nextcloud / SabreDAV) pour alimenter la db locale via le pipeline
+d'import. Aujourd'hui, `cmd_import` ([cli.py:113](../src/multicorpus_engine/cli.py#L113))
+ne lit qu'**un fichier local unique** (`--path`) et dispatche par `--mode` vers
+l'importer correspondant ([cli.py:147-237](../src/multicorpus_engine/cli.py#L147)).
+
+La db reste **strictement locale** : on ne partage rien par WebDAV, on ne fait
+qu'**ingérer en entrée**.
+
+# Périmètre
+
+Fichiers **créés** :
+- `src/multicorpus_engine/remote/__init__.py`
+- `src/multicorpus_engine/remote/webdav.py` — client WebDAV stdlib (PROPFIND + GET).
+- `src/multicorpus_engine/importers/dispatch.py` — helper de dispatch extrait.
+- `tests/test_webdav_client.py`, `tests/test_import_remote_batch.py`.
+
+Fichiers **modifiés** :
+- `src/multicorpus_engine/cli.py` — `cmd_import` réécrit pour appeler le helper ;
+  nouvelle sous-commande `import-remote`.
+- `CHANGELOG.md`, [docs/DESIGN_sharedocs_ingestion.md](DESIGN_sharedocs_ingestion.md)
+  (cocher Phase 1).
+
+**Interdit en Phase 1** : toucher au sidecar, au frontend, ajouter une dépendance
+(`webdav4`/`httpx` proscrits), migrer la db.
+
+# Décisions de design (figées — ne pas re-débattre dans le code)
+
+1. **stdlib uniquement.** WebDAV via `urllib.request` (`Request(method="PROPFIND")`,
+   `urlopen`) ; parsing du `207 Multi-Status` via **`defusedxml.ElementTree`**
+   (déjà dépendance, protège XXE). Aucune lib tierce.
+2. **PROPFIND `Depth: "1"` strict** — jamais `infinity`. La première entrée du
+   listing est le dossier lui-même → la sauter (`href == chemin demandé`). Les
+   `href` sont percent-encodés et souvent absolus côté serveur
+   (`/remote.php/dav/files/...`) → résoudre contre `scheme://host` de l'URL de base.
+3. **GET en streaming** (chunks 4 MiB) vers un fichier temp. Intégrité = **taille
+   seule** (Content-Length vs octets écrits), pas d'ETag. Garde `--max-file-mb`
+   (défaut **200**) : au-delà → `skipped-oversize`.
+4. **Auth** : `basic` / `bearer` / `anonymous`. **TLS toujours vérifié**, aucun
+   opt-out. Résolution (`--auth auto`) :
+   `AGRAFES_WEBDAV_TOKEN` → bearer ; sinon `AGRAFES_WEBDAV_USER`+`AGRAFES_WEBDAV_PASSWORD`
+   → basic ; sinon anonymous. `--auth {basic,bearer,anonymous}` force le mode.
+5. **Credentials jamais persistés** : ni db, ni `runs.params`, ni logs de run, ni
+   stdout. `runs.params` ne contient que `url` + `mode`. Exclure tout header
+   `Authorization` des logs.
+6. **Flux batch** : PROPFIND dossier → filtrer fichiers par extension dérivée du
+   `--mode` (`docx_* → *.docx`, `odt_* → *.odt`, `txt_* → *.txt`, `tei → *.xml`,
+   `conllu → *.conllu`), surchargeable via `--include "<glob>"`. Non-correspondants
+   → `skipped-filtered`.
+7. **Dédup** : télécharger → hasher (même helper `_compute_file_hash` que les
+   importers) → si un `documents.source_hash` identique existe déjà →
+   `skipped-duplicate`, **sans créer de run**. (Aligné ADR-011.)
+8. **Un run par fichier** (modèle 1-fichier-1-run inchangé). Provenance : après
+   import, `UPDATE documents SET source_path = <url_distante> WHERE doc_id = <renvoyé>` ;
+   `source_hash` (octets) inchangé. Ne **pas** modifier la signature des importers.
+9. **Robustesse** : une erreur (download ou import) sur un fichier est reportée et
+   **n'interrompt pas** le batch.
+10. **Temp** : `tempfile.mkdtemp()` par batch, supprimé en `finally`. **Noms de
+    fichiers temp générés** — jamais construits depuis le nom serveur (garde
+    traversée de chemin).
+
+## Cas à gérer
+
+| Cas | Comportement |
+|---|---|
+| URL pointe sur un fichier, pas un dossier | Erreur claire « --url doit pointer un dossier WebDAV ». |
+| `401` au PROPFIND/GET | Message d'auth explicite (pas de stacktrace). |
+| `404` (dossier introuvable) | Message clair. |
+| Timeout / `URLError` réseau | Message réseau, code de sortie non-zéro. |
+| Dossier vide ou 0 fichier après filtre | Report avec totaux à 0, message « aucun fichier correspondant à <glob/mode> ». |
+| Fichier > `--max-file-mb` | `skipped-oversize`, pas de download complet (vérifier Content-Length au PROPFIND ; sinon couper le stream). |
+| `getcontentlength` absent dans le PROPFIND | Tolérer (taille inconnue) ; skip le contrôle d'intégrité taille pour ce fichier, le noter. |
+
+# Livrables
+
+## L1 — Helper de dispatch (refactor préalable)
+
+Créer `importers/dispatch.py` :
+```python
+def dispatch_import(conn, *, mode, path, language, title=None,
+                    doc_role="standalone", resource_type=None,
+                    tei_unit="p", run_id, run_logger):
+    """Route vers l'importer selon `mode`. Retourne le Report de l'importer.
+    Lève ValueError sur mode inconnu."""
+```
+- Déplacer le if/elif `mode → importer` de [cli.py:147-237](../src/multicorpus_engine/cli.py#L147)
+  dans ce helper, **à l'identique** (imports paresseux conservés).
+- Réécrire `cmd_import` pour : créer le run, appeler `dispatch_import(...)`,
+  `update_run_stats`, `_ok(...)`. Comportement CLI `import` **strictement
+  inchangé** (vérifier via la suite de tests existante).
+- **doc_id** : `import-remote` (L3) a besoin du `doc_id` créé. Vérifier si le
+  Report l'expose déjà ; sinon, l'ajouter comme champ du report (une fois, propre)
+  ou le faire retourner par `dispatch_import`. Ne pas le récupérer par un
+  `SELECT MAX(doc_id)` fragile.
+
+## L2 — Client WebDAV (`remote/webdav.py`)
+
+API minimale, fonctionnelle, sans état lourd :
+```python
+def build_auth_header(mode, *, user=None, password=None, token=None) -> dict
+def propfind(url, *, auth_header, timeout=30) -> list[RemoteEntry]
+def download(url, dest_path, *, auth_header, max_bytes, timeout=30) -> int  # octets écrits
+```
+- `RemoteEntry` (dataclass) : `name`, `href` (URL absolue résolue), `is_dir`,
+  `size`, `modified`, `content_type`.
+- `propfind` envoie `Depth: 1` + corps XML minimal, parse via `defusedxml`,
+  saute l'entrée self, résout les href.
+- Mapping d'erreurs en exceptions maison claires
+  (`WebdavAuthError`, `WebdavNotFound`, `WebdavError`).
+
+## L3 — Sous-commande CLI `import-remote`
+
+```
+multicorpus import-remote --db <db> --url <folder-url> --mode <mode>
+    [--language fr] [--include "*.docx"] [--auth auto]
+    [--doc-role standalone] [--resource-type ...] [--max-file-mb 200]
+```
+- Orchestration : résoudre auth (env + `--auth`) → `propfind` → filtrer → pour
+  chaque fichier : `download` → hash → dédup → `dispatch_import` (1 run) →
+  UPDATE `source_path`. Continue sur erreur. Temp nettoyé en `finally`.
+- **Report batch JSON** (style `_ok`) : par fichier `{status, source_url, doc_id,
+  run_id, source_hash, ...compteurs, error?}` avec `status` ∈ {`imported`,
+  `skipped-duplicate`, `skipped-filtered`, `skipped-oversize`, `error`} + un
+  agrégat `{total, imported, skipped_*, errors}`.
+- Code de sortie non-zéro si au moins une erreur **bloquante** (auth/réseau global) ;
+  les erreurs par fichier ne font pas échouer le batch entier.
+
+## L4 — Tests (pytest)
+
+`tests/test_webdav_client.py` — `urlopen` mocké :
+- Échantillon `207` multistatus (1 dossier-self + 2 fichiers + 1 sous-dossier) →
+  `propfind` renvoie les 2 fichiers + 1 dossier, self exclu, href résolus absolus.
+- Construction header auth basic/bearer/anonymous.
+- Mapping `401` → `WebdavAuthError`, `404` → `WebdavNotFound`, timeout → `WebdavError`.
+- `download` respecte `max_bytes` (oversize coupé).
+
+`tests/test_import_remote_batch.py` — WebDAV mocké, vraie db temp :
+- Dossier mixte (docx/odt/txt/xml + un `.pdf` parasite) avec `--mode docx_numbered_lines`
+  → seuls les `.docx` importés, `.pdf` → `skipped-filtered`.
+- Re-run identique → tout `skipped-duplicate`, aucun nouveau run.
+- Un download qui lève → ce fichier `error`, les autres importés.
+- Provenance : `documents.source_path == url distante`, `source_hash` = hash octets.
+- Fichier oversize → `skipped-oversize`.
+
+`tests/` existants d'import → doivent rester **verts** (régression du refactor L1).
+
+## L5 — Documentation
+
+- `CHANGELOG.md` — entrée `[Unreleased] / Added` : « `import-remote` : ingestion
+  batch depuis un dépôt WebDAV (ShareDocs Huma-Num) ».
+- [docs/DESIGN_sharedocs_ingestion.md](DESIGN_sharedocs_ingestion.md) — cocher
+  « Phase 1 » comme livrée, avec lien commit.
+
+# Conventions du repo
+
+- Commits Conventional par livrable :
+  - `refactor(prep): extract mode→importer dispatch into dispatch_import`
+  - `feat(prep): stdlib WebDAV client (PROPFIND + GET) for remote ingestion`
+  - `feat(prep): import-remote CLI — batch ingest from a WebDAV folder`
+  - `test(prep): WebDAV client + import-remote batch edge cases`
+  - `docs(prep): document import-remote (ShareDocs ingestion phase 1)`
+- Pas de migration DB. Pas de bump de version.
+
+# Ordre d'exécution
+
+1. L1 (refactor dispatch) + faire passer la suite d'import existante (régression).
+2. L2 (client WebDAV) + ses tests.
+3. L3 (`import-remote`) + L4 tests batch.
+4. L5 doc.
+
+# Ce qu'il NE FAUT PAS faire
+
+- Pas de sidecar, pas de frontend (phases 2-3).
+- Pas de `webdav4`/`httpx` ni aucune nouvelle dépendance.
+- Pas d'opt-out TLS, pas de `Depth: infinity`.
+- Aucun credential en db / `runs.params` / logs / stdout.
+- Pas de PUT/upload, pas de partage de db (hors périmètre, cf. design §1).
+- Pas de modification des signatures d'importers (provenance via UPDATE post-import).
+
+# Si tu butes
+
+- Si `urllib` rechigne sur la méthode `PROPFIND`, passer `method="PROPFIND"` à
+  `Request` (supporté Python ≥3.3) ; ne pas retomber sur une lib tierce.
+- Si un serveur renvoie des href relatifs, résoudre via `urllib.parse.urljoin`
+  contre l'URL de base.
+- Si une décision ambiguë bloque, choisir la **moins invasive** et `// NOTE:`.
+
+# Livrable attendu
+
+4-5 commits + court résumé final : ce qui marche (scénarios testés), ce qui n'a pu
+être fait et pourquoi, les `// NOTE:` laissés, bugs pré-existants rencontrés,
+recommandation pour la Phase 2 (sidecar).

--- a/docs/TICKET_SHAREDOCS_INGESTION_P2_SIDECAR.md
+++ b/docs/TICKET_SHAREDOCS_INGESTION_P2_SIDECAR.md
@@ -1,0 +1,111 @@
+# Mission : Connecteur d'ingestion ShareDocs — Phase 2 (endpoints sidecar)
+
+Tu interviens sur le repo AGRAFES (branche `development`).
+
+**Prérequis : la Phase 1 ([TICKET_SHAREDOCS_INGESTION_P1_CLI.md](TICKET_SHAREDOCS_INGESTION_P1_CLI.md))
+est mergée** — `remote/webdav.py`, `importers/dispatch.py` et la sous-commande
+`import-remote` existent. Lis d'abord
+[docs/DESIGN_sharedocs_ingestion.md](DESIGN_sharedocs_ingestion.md) (§5 phase 2,
+§6 sécurité) puis [HANDOFF_PREP.md](../HANDOFF_PREP.md).
+
+# Contexte
+
+Exposer l'ingestion ShareDocs au sidecar HTTP pour que l'UI (phase 3) puisse
+parcourir un dépôt et lancer un import batch. Le sidecar fait déjà du HTTP stdlib
+et possède une mécanique de progression d'op longue : `JobManager` +
+`_track_stage("import")` autour du `POST /import`
+([sidecar.py:738-740](../src/multicorpus_engine/sidecar.py#L738)). On la réutilise.
+
+# Périmètre
+
+Fichiers **modifiés** :
+- `src/multicorpus_engine/sidecar.py` — 2 routes + handlers.
+- `src/multicorpus_engine/sidecar_contract.py` — schémas requête/réponse.
+- `docs/SIDECAR_API_CONTRACT.md`, `docs/openapi.json` (régénéré), `CHANGELOG.md`.
+- `tests/` — tests d'intégration sidecar.
+
+**Interdit** : frontend (phase 3), nouvelle dépendance, migration DB, modifier la
+logique métier de Phase 1 (réutiliser `propfind`/`download`/`dispatch_import` tels
+quels ; si un ajustement de signature est nécessaire, le faire minimal et le noter).
+
+# Décisions de design (figées)
+
+1. **`POST /webdav/list`** — lecture seule réseau. Body :
+   `{url, auth: {mode, user?, password?, token?}}`. Renvoie
+   `{entries: [{name, href, is_dir, size, modified, content_type}]}`.
+   **Hors write-lock** (ne bloque pas les écritures db). Réponse rapide, pas de
+   `JobManager` nécessaire.
+2. **`POST /import-remote`** — opération d'écriture. Body :
+   `{url, mode, language?, include?, auth:{...}, doc_role?, resource_type?, max_file_mb?}`.
+   - Sous **`_track_stage("import-remote")` + write-lock** (même protection que
+     `/import`).
+   - Progression **par fichier** via `JobManager` (calquer exactement la façon dont
+     `/import` émet ses stages — lire `sidecar_jobs.py` et `_handle_import`).
+   - Renvoie le **même report batch** que la CLI de Phase 1.
+3. Ajouter `"/webdav/list"` et `"/import-remote"` à la liste des routes POST
+   autorisées ([sidecar.py:671](../src/multicorpus_engine/sidecar.py#L671)).
+4. **Credentials** : reçus dans le body sur `127.0.0.1` uniquement, gardés **en
+   mémoire** le temps de la requête. **Jamais** écrits en db, `runs.params` (qui ne
+   contient que `url`+`mode`), logs de requête, ni télémétrie. Exclure les champs
+   `auth.*` de tout body loggé.
+5. **Erreurs** : auth/réseau global (PROPFIND en échec) → `400`/`502` avec message
+   clair ; erreurs par fichier → dans le report, `200` global.
+
+# Livrables
+
+## L1 — `POST /webdav/list`
+Handler `_handle_webdav_list(body)` : valide `url` + `auth`, appelle
+`remote.webdav.propfind`, mappe les `RemoteEntry` en JSON. Erreurs WebDAV →
+codes HTTP appropriés (`401→401`, `404→404`, réseau→`502`).
+
+## L2 — `POST /import-remote`
+Handler `_handle_import_remote(body)` : réutilise l'orchestration batch de Phase 1
+(extraire cette orchestration dans une fonction partagée si elle est encore inline
+dans `cmd_import_remote` — sinon l'importer telle quelle). Émettre la progression
+par fichier via `JobManager`. Retourner le report batch.
+
+## L3 — Contrat & OpenAPI
+- `sidecar_contract.py` : schémas des 2 requêtes + réponses. `auth` est un objet ;
+  documenter que les creds ne sont jamais persistés.
+- `docs/SIDECAR_API_CONTRACT.md` : documenter les 2 routes.
+- `docs/openapi.json` : régénérer (`python scripts/export_openapi.py`).
+
+## L4 — Tests
+- `/webdav/list` : WebDAV mocké → entries JSON ; `401` → `401` ; réseau → `502`.
+- `/import-remote` : WebDAV mocké + db temp → report batch correct ; vérifier que
+  `runs.params` **ne contient aucun credential** ; vérifier qu'aucun log ne fuit le
+  header `Authorization`.
+- Concurrence : `/import-remote` prend bien le write-lock (pas de course avec un
+  `/import` simultané).
+
+## L5 — Doc
+`CHANGELOG.md` `[Unreleased] / Added` ; cocher Phase 2 dans
+[docs/DESIGN_sharedocs_ingestion.md](DESIGN_sharedocs_ingestion.md).
+
+# Conventions du repo
+- `feat(prep): sidecar /webdav/list endpoint (PROPFIND browse)`
+- `feat(prep): sidecar /import-remote endpoint with JobManager progress`
+- `docs(prep): contract + openapi for ShareDocs ingestion endpoints`
+- `test(prep): sidecar ShareDocs endpoints + credential non-persistence`
+- Pas de migration DB, pas de bump de version.
+
+# Ordre d'exécution
+1. Lire `sidecar_jobs.py` + `_handle_import` pour la forme exacte des events de
+   progression. 2. L1 (`/webdav/list`). 3. L2 (`/import-remote`) + progression.
+   4. L3 contrat/openapi. 5. L4 tests. 6. L5 doc.
+
+# Ce qu'il NE FAUT PAS faire
+- Pas de frontend (phase 3). Pas de nouvelle dépendance.
+- Aucun credential persisté nulle part ; `auth.*` hors des logs.
+- Pas de PUT/upload, pas de partage de db.
+- Ne pas mettre `/webdav/list` derrière le write-lock (c'est de la lecture réseau).
+
+# Si tu butes
+- Si la progression `JobManager` par fichier est lourde à câbler, émettre au minimum
+  un stage par fichier (début/fin) plutôt que rien, et `// NOTE:` un raffinement.
+- Si l'orchestration batch de Phase 1 n'est pas factorisable proprement, l'extraire
+  dans `remote/ingest.py` et faire pointer CLI + sidecar dessus.
+
+# Livrable attendu
+3-4 commits + résumé : ce qui marche, fuites de creds vérifiées absentes, `// NOTE:`,
+recommandation pour la Phase 3 (UI).

--- a/docs/TICKET_SHAREDOCS_INGESTION_P3_UI.md
+++ b/docs/TICKET_SHAREDOCS_INGESTION_P3_UI.md
@@ -1,0 +1,109 @@
+# Mission : Connecteur d'ingestion ShareDocs — Phase 3 (UI Prep)
+
+Tu interviens sur le repo AGRAFES (branche `development`).
+
+**Prérequis : les Phases 1 et 2 sont mergées** — les endpoints
+`POST /webdav/list` et `POST /import-remote` existent et renvoient le report batch.
+Lis [docs/DESIGN_sharedocs_ingestion.md](DESIGN_sharedocs_ingestion.md) (§5 phase 3),
+[docs/SIDECAR_API_CONTRACT.md](SIDECAR_API_CONTRACT.md) (les 2 routes) et
+[HANDOFF_PREP.md](../HANDOFF_PREP.md).
+
+# Contexte
+
+Donner aux utilisateurs non-CLI un écran Prep pour parcourir un dépôt ShareDocs et
+ingérer un dossier d'un coup, avec progression et report. Réutiliser intégralement
+les endpoints de Phase 2 (aucune logique métier nouvelle côté front).
+
+# Périmètre
+
+Avant de coder, **lire un écran existant** pour calquer la structure, les
+conventions de style et le câblage sidecar : `tauri-prep/src/screens/ImportScreen.ts`
+(le plus proche fonctionnellement) + le flux `tauri-prep/src/lib/prepNextStep.ts` /
+`tauri-prep/src/components/NextStepBanner.ts` pour l'intégration dans le parcours.
+
+Fichiers **créés/modifiés** (à ajuster selon ce que tu observes) :
+- `tauri-prep/src/screens/ShareDocsImportScreen.ts` (nouveau).
+- Enregistrement de l'écran dans le routeur/app (`tauri-prep/src/app.ts`).
+- Client API sidecar : ajouter les appels `webdavList` / `importRemote`.
+- Tests Vitest si la logique de filtrage/affichage le justifie.
+
+**Interdit** : modifier la logique backend (Phases 1-2), ajouter une dépendance front
+lourde, persister des credentials sur disque.
+
+# Décisions de design (figées)
+
+1. **Flux écran** :
+   - Formulaire connexion : URL de base + mode d'auth (anonymous / basic / bearer)
+     + champs creds conditionnels.
+   - « Connecter » → `POST /webdav/list` → liste navigable (nom, type, taille,
+     modifié) ; clic sur un dossier → re-`list` ce dossier.
+   - Sur un dossier : choisir `mode` (mêmes valeurs que l'import classique) +
+     `language` + filtre `include` optionnel → « Importer ce dossier ».
+   - `POST /import-remote` → **barre de progression** (events `JobManager`, même
+     mécanisme que l'écran d'import classique) → **table de report** par fichier
+     (status, doc, taille, erreur).
+2. **Credentials** : saisis dans le formulaire, envoyés au sidecar à chaque appel,
+   gardés **en mémoire de session uniquement** (état du composant). **Jamais**
+   écrits sur disque / `localStorage` / config. Re-saisie à la session suivante.
+   (Compromis UX assumé ; keychain OS = évolution ultérieure, hors périmètre.)
+3. **Report** : réutiliser le rendu de report d'import existant si possible ;
+   sinon une table simple. Coloration par `status` (`imported` vs `skipped-*` vs
+   `error`).
+4. **Pas de re-décision métier côté front** : extensions filtrées, dédup, provenance
+   sont gérées par le backend. Le front affiche ce que le report dit.
+
+# Livrables
+
+## L1 — Client API
+Ajouter au client sidecar : `webdavList({url, auth})` et
+`importRemote({url, mode, language, include, auth, docRole, resourceType, maxFileMb})`,
+typés sur le contrat de Phase 2.
+
+## L2 — Écran ShareDocs
+`ShareDocsImportScreen.ts` : formulaire connexion, navigation dossier, sélection
+mode/langue/filtre, déclenchement import, progression, report. Calquer les
+conventions de `ImportScreen.ts`.
+
+## L3 — Intégration parcours
+Rendre l'écran accessible (entrée de navigation Prep). Si pertinent, le relier au
+`NextStepBanner` (« importer depuis ShareDocs » comme alternative à l'import local).
+
+## L4 — Tests
+Vitest sur la logique purement front si elle existe (formatage du report, états du
+formulaire d'auth selon le mode). Pas de test e2e réseau réel.
+
+## L5 — Doc
+`CHANGELOG.md` `[Unreleased] / Added` ; cocher Phase 3 dans
+[docs/DESIGN_sharedocs_ingestion.md](DESIGN_sharedocs_ingestion.md) ; mettre à jour
+[docs/UX_FLOW_PREP.md](UX_FLOW_PREP.md) avec le nouveau point d'entrée.
+
+# Conventions du repo
+- `feat(prep): ShareDocs import screen (browse + batch ingest)`
+- `feat(prep): sidecar client bindings for webdav/list + import-remote`
+- `test(prep): ShareDocs screen report rendering + auth form states`
+- `docs(prep): document ShareDocs import flow`
+- Pas de migration DB, pas de bump de version.
+
+# Ordre d'exécution
+1. Lire `ImportScreen.ts` + le flux existant. 2. L1 client API. 3. L2 écran
+   (connexion → navigation → import → progression → report). 4. L3 intégration.
+   5. L4 tests. 6. L5 doc. 7. Smoke test manuel contre un vrai dépôt ShareDocs.
+
+# Ce qu'il NE FAUT PAS faire
+- Persister des credentials (disque / `localStorage` / config). Mémoire de session
+  seulement.
+- Dupliquer la logique métier (filtre/dédup/provenance vit dans le backend).
+- Modifier les Phases 1-2 hors correctif mineur (et alors le noter).
+- Ajouter une dépendance front lourde pour un picker de fichiers — la liste
+  `/webdav/list` suffit.
+
+# Si tu butes
+- Si la progression par fichier n'est pas exposée assez finement par
+  `/import-remote`, afficher une progression indéterminée + le report final, et
+  `// NOTE:` le raffinement.
+- Si l'intégration `NextStepBanner` est ambiguë, livrer d'abord l'écran autonome
+  accessible via la navigation, et traiter le banner en follow-up.
+
+# Livrable attendu
+3-4 commits + résumé : ce qui marche (smoke test ShareDocs), ce qui manque, les
+`// NOTE:`, recommandation (ex. persistance creds via keychain, progression fine).

--- a/src/multicorpus_engine/cli.py
+++ b/src/multicorpus_engine/cli.py
@@ -114,7 +114,7 @@ def cmd_import(args: argparse.Namespace) -> None:
     from .db.connection import get_connection
     from .db.migrations import apply_migrations
     from .runs import create_run, setup_run_logger, update_run_stats, utcnow_iso
-    from .importers.docx_numbered_lines import import_docx_numbered_lines
+    from .importers.dispatch import dispatch_import
 
     db_path = Path(args.db).resolve()
     if not db_path.exists():
@@ -144,97 +144,18 @@ def cmd_import(args: argparse.Namespace) -> None:
                 "created_at": utcnow_iso(),
             })
 
-        if args.mode == "docx_numbered_lines":
-            report = import_docx_numbered_lines(
-                conn=conn,
-                path=import_path,
-                language=args.language,
-                title=getattr(args, "title", None),
-                doc_role=getattr(args, "doc_role", "standalone"),
-                resource_type=getattr(args, "resource_type", None),
-                run_id=run_id,
-                run_logger=log,
-            )
-        elif args.mode == "txt_numbered_lines":
-            from .importers.txt import import_txt_numbered_lines
-            report = import_txt_numbered_lines(
-                conn=conn,
-                path=import_path,
-                language=args.language,
-                title=getattr(args, "title", None),
-                doc_role=getattr(args, "doc_role", "standalone"),
-                resource_type=getattr(args, "resource_type", None),
-                run_id=run_id,
-                run_logger=log,
-            )
-        elif args.mode == "docx_paragraphs":
-            from .importers.docx_paragraphs import import_docx_paragraphs
-            report = import_docx_paragraphs(
-                conn=conn,
-                path=import_path,
-                language=args.language,
-                title=getattr(args, "title", None),
-                doc_role=getattr(args, "doc_role", "standalone"),
-                resource_type=getattr(args, "resource_type", None),
-                run_id=run_id,
-                run_logger=log,
-            )
-        elif args.mode == "odt_paragraphs":
-            from .importers.odt_paragraphs import import_odt_paragraphs
-            report = import_odt_paragraphs(
-                conn=conn,
-                path=import_path,
-                language=args.language,
-                title=getattr(args, "title", None),
-                doc_role=getattr(args, "doc_role", "standalone"),
-                resource_type=getattr(args, "resource_type", None),
-                run_id=run_id,
-                run_logger=log,
-            )
-        elif args.mode == "odt_numbered_lines":
-            from .importers.odt_numbered_lines import import_odt_numbered_lines
-            report = import_odt_numbered_lines(
-                conn=conn,
-                path=import_path,
-                language=args.language,
-                title=getattr(args, "title", None),
-                doc_role=getattr(args, "doc_role", "standalone"),
-                resource_type=getattr(args, "resource_type", None),
-                run_id=run_id,
-                run_logger=log,
-            )
-        elif args.mode == "tei":
-            from .importers.tei_importer import import_tei
-            report = import_tei(
-                conn=conn,
-                path=import_path,
-                language=getattr(args, "language", None),
-                title=getattr(args, "title", None),
-                doc_role=getattr(args, "doc_role", "standalone"),
-                resource_type=getattr(args, "resource_type", None),
-                unit_element=getattr(args, "tei_unit", "p"),
-                run_id=run_id,
-                run_logger=log,
-            )
-        elif args.mode == "conllu":
-            from .importers.conllu import import_conllu
-            report = import_conllu(
-                conn=conn,
-                path=import_path,
-                language=args.language,
-                title=getattr(args, "title", None),
-                doc_role=getattr(args, "doc_role", "standalone"),
-                resource_type=getattr(args, "resource_type", None),
-                run_id=run_id,
-                run_logger=log,
-            )
-        else:
-            _err({
-                "run_id": run_id,
-                "error": f"Unknown import mode: {args.mode!r}",
-                "created_at": utcnow_iso(),
-            })
-            return
+        report = dispatch_import(
+            conn,
+            mode=args.mode,
+            path=import_path,
+            language=args.language,
+            title=getattr(args, "title", None),
+            doc_role=getattr(args, "doc_role", "standalone"),
+            resource_type=getattr(args, "resource_type", None),
+            tei_unit=getattr(args, "tei_unit", "p"),
+            run_id=run_id,
+            run_logger=log,
+        )
 
         stats = report.to_dict()
         update_run_stats(conn, run_id, stats)
@@ -255,6 +176,83 @@ def cmd_import(args: argparse.Namespace) -> None:
     except Exception as exc:
         log.error("Import failed: %s\n%s", exc, traceback.format_exc())
         _err({"run_id": run_id, "error": str(exc), "created_at": utcnow_iso()})
+
+
+# ---------------------------------------------------------------------------
+# import-remote (WebDAV / ShareDocs)
+# ---------------------------------------------------------------------------
+
+def _resolve_webdav_auth(explicit: str) -> tuple[str, dict]:
+    """Resolve the auth mode + Authorization header from --auth and env vars.
+
+    Credentials come only from the environment, never from the CLI line or the
+    db: ``AGRAFES_WEBDAV_TOKEN`` (bearer) or ``AGRAFES_WEBDAV_USER`` +
+    ``AGRAFES_WEBDAV_PASSWORD`` (basic). Raises ``ValueError`` on invalid combos.
+    """
+    import os
+
+    from .remote.webdav import build_auth_header
+
+    token = os.environ.get("AGRAFES_WEBDAV_TOKEN")
+    user = os.environ.get("AGRAFES_WEBDAV_USER")
+    password = os.environ.get("AGRAFES_WEBDAV_PASSWORD")
+
+    mode = explicit
+    if mode == "auto":
+        if token:
+            mode = "bearer"
+        elif user and password is not None:
+            mode = "basic"
+        else:
+            mode = "anonymous"
+    return mode, build_auth_header(mode, user=user, password=password, token=token)
+
+
+def cmd_import_remote(args: argparse.Namespace) -> None:
+    from .db.connection import get_connection
+    from .db.migrations import apply_migrations
+    from .runs import utcnow_iso
+    from .remote import webdav
+    from .remote.ingest import ingest_remote_folder
+
+    db_path = Path(args.db).resolve()
+    if not db_path.exists():
+        _err({"error": f"DB not found: {db_path}. Run init-project first.", "created_at": utcnow_iso()})
+
+    # Non-TEI modes require --language (mirrors `import`).
+    if args.mode != "tei" and not args.language:
+        _err({"error": "--language is required for this import mode", "created_at": utcnow_iso()})
+
+    try:
+        auth_mode, auth_header = _resolve_webdav_auth(args.auth)
+    except ValueError as exc:
+        _err({"error": str(exc), "created_at": utcnow_iso()})
+
+    conn = get_connection(db_path)
+    apply_migrations(conn)
+
+    try:
+        report = ingest_remote_folder(
+            conn,
+            db_path,
+            url=args.url,
+            mode=args.mode,
+            language=args.language,
+            include=args.include,
+            doc_role=args.doc_role,
+            resource_type=args.resource_type,
+            auth_header=auth_header,
+            max_file_mb=args.max_file_mb,
+        )
+    except webdav.WebdavAuthError as exc:
+        _err({"error": str(exc), "hint": "check AGRAFES_WEBDAV_* environment variables", "created_at": utcnow_iso()})
+    except webdav.WebdavNotFound as exc:
+        _err({"error": str(exc), "created_at": utcnow_iso()})
+    except webdav.WebdavError as exc:
+        _err({"error": str(exc), "created_at": utcnow_iso()})
+
+    # Per-file errors are reported but do not fail the batch (design §9).
+    _ok({"auth_mode": auth_mode, "created_at": utcnow_iso(), **report})
 
 
 # ---------------------------------------------------------------------------
@@ -1383,6 +1381,55 @@ def build_parser() -> argparse.ArgumentParser:
         help="TEI unit element: 'p' (paragraphs, default) or 's' (sentences)",
     )
     p_import.set_defaults(func=cmd_import)
+
+    # import-remote (WebDAV / ShareDocs)
+    p_import_remote = sub.add_parser(
+        "import-remote",
+        help="Batch-import every matching file in a WebDAV folder (e.g. ShareDocs)",
+    )
+    p_import_remote.add_argument("--db", required=True)
+    p_import_remote.add_argument("--url", required=True, help="WebDAV folder (collection) URL")
+    p_import_remote.add_argument(
+        "--mode",
+        required=True,
+        choices=[
+            "docx_numbered_lines",
+            "txt_numbered_lines",
+            "docx_paragraphs",
+            "odt_paragraphs",
+            "odt_numbered_lines",
+            "tei",
+            "conllu",
+        ],
+        help="Import mode applied to every matching file",
+    )
+    p_import_remote.add_argument("--language", default=None, help="ISO language code (required except for tei)")
+    p_import_remote.add_argument(
+        "--include",
+        default=None,
+        help="Glob to filter filenames (default: files matching the --mode extension)",
+    )
+    p_import_remote.add_argument(
+        "--auth",
+        default="auto",
+        choices=["auto", "basic", "bearer", "anonymous"],
+        help="Auth mode. 'auto' reads AGRAFES_WEBDAV_TOKEN or AGRAFES_WEBDAV_USER/PASSWORD",
+    )
+    p_import_remote.add_argument(
+        "--doc-role",
+        dest="doc_role",
+        default="standalone",
+        choices=["original", "translation", "excerpt", "standalone", "unknown"],
+    )
+    p_import_remote.add_argument("--resource-type", dest="resource_type", default=None)
+    p_import_remote.add_argument(
+        "--max-file-mb",
+        dest="max_file_mb",
+        type=float,
+        default=200.0,
+        help="Skip files larger than this size, in MiB (default 200)",
+    )
+    p_import_remote.set_defaults(func=cmd_import_remote)
 
     # index
     p_index = sub.add_parser("index", help="Rebuild/update the FTS5 index")

--- a/src/multicorpus_engine/importers/dispatch.py
+++ b/src/multicorpus_engine/importers/dispatch.py
@@ -1,0 +1,104 @@
+"""Central mode→importer dispatch.
+
+Single source of truth for routing an import *mode* to its importer. Shared by
+the CLI (``import`` and ``import-remote``); the sidecar's ``/import`` handler is
+expected to converge on this helper (see docs/TICKET_SHAREDOCS_INGESTION_P2_SIDECAR.md)
+so the mode→importer mapping lives in exactly one place.
+
+Lazy imports keep each importer's optional dependencies (python-docx, defusedxml,
+…) off the import path for modes that do not need them.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+#: Import modes accepted by :func:`dispatch_import` — kept in sync with the CLI
+#: ``--mode`` choices.
+IMPORT_MODES = (
+    "docx_numbered_lines",
+    "txt_numbered_lines",
+    "docx_paragraphs",
+    "odt_paragraphs",
+    "odt_numbered_lines",
+    "tei",
+    "conllu",
+)
+
+
+def dispatch_import(
+    conn: sqlite3.Connection,
+    *,
+    mode: str,
+    path: str | Path,
+    language: Optional[str],
+    title: Optional[str] = None,
+    doc_role: str = "standalone",
+    resource_type: Optional[str] = None,
+    tei_unit: str = "p",
+    column_index: Optional[int] = None,
+    run_id: Optional[str] = None,
+    run_logger: Optional[logging.Logger] = None,
+):
+    """Route to the importer for *mode* and return its ``ImportReport``.
+
+    The ``ImportReport`` exposes ``doc_id`` (via ``to_dict()``), which callers
+    use to attach provenance after the import.
+
+    Raises ``ValueError`` for an unknown *mode*. ``column_index`` and ``tei_unit``
+    are only meaningful for ``docx_numbered_lines`` and ``tei`` respectively; they
+    are ignored for the other modes.
+    """
+    if mode == "docx_numbered_lines":
+        from .docx_numbered_lines import import_docx_numbered_lines
+        return import_docx_numbered_lines(
+            conn=conn, path=path, language=language, title=title,
+            doc_role=doc_role, resource_type=resource_type,
+            column_index=column_index, run_id=run_id, run_logger=run_logger,
+        )
+    if mode == "txt_numbered_lines":
+        from .txt import import_txt_numbered_lines
+        return import_txt_numbered_lines(
+            conn=conn, path=path, language=language, title=title,
+            doc_role=doc_role, resource_type=resource_type,
+            run_id=run_id, run_logger=run_logger,
+        )
+    if mode == "docx_paragraphs":
+        from .docx_paragraphs import import_docx_paragraphs
+        return import_docx_paragraphs(
+            conn=conn, path=path, language=language, title=title,
+            doc_role=doc_role, resource_type=resource_type,
+            run_id=run_id, run_logger=run_logger,
+        )
+    if mode == "odt_paragraphs":
+        from .odt_paragraphs import import_odt_paragraphs
+        return import_odt_paragraphs(
+            conn=conn, path=path, language=language, title=title,
+            doc_role=doc_role, resource_type=resource_type,
+            run_id=run_id, run_logger=run_logger,
+        )
+    if mode == "odt_numbered_lines":
+        from .odt_numbered_lines import import_odt_numbered_lines
+        return import_odt_numbered_lines(
+            conn=conn, path=path, language=language, title=title,
+            doc_role=doc_role, resource_type=resource_type,
+            run_id=run_id, run_logger=run_logger,
+        )
+    if mode == "tei":
+        from .tei_importer import import_tei
+        return import_tei(
+            conn=conn, path=path, language=language, title=title,
+            doc_role=doc_role, resource_type=resource_type,
+            unit_element=tei_unit, run_id=run_id, run_logger=run_logger,
+        )
+    if mode == "conllu":
+        from .conllu import import_conllu
+        return import_conllu(
+            conn=conn, path=path, language=language, title=title,
+            doc_role=doc_role, resource_type=resource_type,
+            run_id=run_id, run_logger=run_logger,
+        )
+    raise ValueError(f"Unknown import mode: {mode!r}")

--- a/src/multicorpus_engine/remote/__init__.py
+++ b/src/multicorpus_engine/remote/__init__.py
@@ -1,0 +1,4 @@
+"""Remote source connectors (WebDAV / ShareDocs ingestion).
+
+stdlib-only. See docs/DESIGN_sharedocs_ingestion.md.
+"""

--- a/src/multicorpus_engine/remote/ingest.py
+++ b/src/multicorpus_engine/remote/ingest.py
@@ -1,0 +1,192 @@
+"""Batch ingestion of a remote WebDAV folder into the local corpus.
+
+Browse a collection, then for each matching file: download to a temp file,
+dedup by content hash, import via the shared :func:`dispatch_import`, and attach
+the remote URL as provenance. Returns a structured batch report.
+
+This orchestration is intentionally UI-agnostic so the sidecar's
+``POST /import-remote`` handler (Phase 2) can reuse it verbatim.
+See docs/DESIGN_sharedocs_ingestion.md §4.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import logging
+import os
+import shutil
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from ..importers.dispatch import dispatch_import
+from ..runs import create_run, setup_run_logger, update_run_stats
+from . import webdav
+
+# Filename extension(s) implied by each import mode (used when no --include glob
+# is given). Anything not matching is reported as ``skipped-filtered``.
+_MODE_EXTENSIONS = {
+    "docx_numbered_lines": (".docx",),
+    "docx_paragraphs": (".docx",),
+    "odt_numbered_lines": (".odt",),
+    "odt_paragraphs": (".odt",),
+    "txt_numbered_lines": (".txt",),
+    "tei": (".xml",),
+    "conllu": (".conllu",),
+}
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _matches(name: str, mode: str, include: Optional[str]) -> bool:
+    if include:
+        return fnmatch.fnmatch(name.lower(), include.lower())
+    exts = _MODE_EXTENSIONS.get(mode, ())
+    return name.lower().endswith(exts) if exts else True
+
+
+def ingest_remote_folder(
+    conn: sqlite3.Connection,
+    db_path: str | Path,
+    *,
+    url: str,
+    mode: str,
+    language: Optional[str] = None,
+    include: Optional[str] = None,
+    doc_role: str = "standalone",
+    resource_type: Optional[str] = None,
+    auth_header: dict,
+    max_file_mb: Optional[float] = 200.0,
+    logger: Optional[logging.Logger] = None,
+) -> dict:
+    """Import every matching file in the WebDAV folder at *url*. Returns a report.
+
+    Raises ``webdav.WebdavError`` (or a subclass) only for *blocking* failures
+    (e.g. the folder PROPFIND itself fails). Per-file failures are captured in the
+    report and never abort the batch.
+    """
+    db_path = Path(db_path)
+    max_bytes = int(max_file_mb * 1024 * 1024) if max_file_mb else None
+
+    entries = webdav.propfind(url, auth_header=auth_header)
+    files = [e for e in entries if not e.is_dir]
+
+    results: list[dict] = []
+    tmpdir = Path(tempfile.mkdtemp(prefix="agrafes_webdav_"))
+    try:
+        for entry in files:
+            res = _process_one(
+                conn, db_path, entry,
+                mode=mode, language=language, include=include,
+                doc_role=doc_role, resource_type=resource_type,
+                auth_header=auth_header, max_bytes=max_bytes, tmpdir=tmpdir,
+            )
+            results.append(res)
+            if logger is not None:
+                logger.info("import-remote %s -> %s", entry.name, res["status"])
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    return _summarize(url, mode, results)
+
+
+def _process_one(
+    conn: sqlite3.Connection,
+    db_path: Path,
+    entry: webdav.RemoteEntry,
+    *,
+    mode: str,
+    language: Optional[str],
+    include: Optional[str],
+    doc_role: str,
+    resource_type: Optional[str],
+    auth_header: dict,
+    max_bytes: Optional[int],
+    tmpdir: Path,
+) -> dict:
+    base = {"source_url": entry.href, "name": entry.name, "doc_id": None}
+
+    # 1. Extension / glob filter.
+    if not _matches(entry.name, mode, include):
+        return {**base, "status": "skipped-filtered"}
+
+    # 2. Oversize pre-check (when the server declared a size).
+    if max_bytes is not None and entry.size is not None and entry.size > max_bytes:
+        return {**base, "status": "skipped-oversize", "size": entry.size}
+
+    # 3. Download to a generated temp name (never trust the server name for the
+    #    local path — path-traversal guard).
+    fd, tmp_name = tempfile.mkstemp(suffix=Path(entry.name).suffix, dir=str(tmpdir))
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    try:
+        webdav.download(entry.href, tmp_path, auth_header=auth_header, max_bytes=max_bytes)
+    except webdav.WebdavTooLarge:
+        return {**base, "status": "skipped-oversize", "size": entry.size}
+    except webdav.WebdavError as exc:
+        return {**base, "status": "error", "error": str(exc)}
+
+    # 4. Dedup by content hash (same hash the importers persist as source_hash).
+    digest = _sha256(tmp_path)
+    row = conn.execute(
+        "SELECT doc_id FROM documents WHERE source_hash = ? LIMIT 1", (digest,)
+    ).fetchone()
+    if row is not None:
+        return {**base, "status": "skipped-duplicate", "doc_id": row["doc_id"], "source_hash": digest}
+
+    # 5. Import — one run per file (1-file-1-run model, unchanged).
+    run_id = create_run(conn, "import-remote", {"url": entry.href, "mode": mode})
+    log, _ = setup_run_logger(db_path, run_id)
+    try:
+        report = dispatch_import(
+            conn, mode=mode, path=str(tmp_path), language=language,
+            doc_role=doc_role, resource_type=resource_type,
+            run_id=run_id, run_logger=log,
+        )
+        stats = report.to_dict()
+        doc_id = stats.get("doc_id")
+        # Provenance: replace the temp path with the remote URL (source_hash stays).
+        if doc_id:
+            conn.execute(
+                "UPDATE documents SET source_path = ? WHERE doc_id = ?", (entry.href, doc_id)
+            )
+            conn.commit()
+        update_run_stats(conn, run_id, {**stats, "source_url": entry.href})
+        return {
+            **base,
+            "status": "imported",
+            "doc_id": doc_id,
+            "run_id": run_id,
+            "source_hash": digest,
+            "units_total": stats.get("units_total"),
+            "units_line": stats.get("units_line"),
+        }
+    except Exception as exc:  # per-file import failure — report and continue
+        if log is not None:
+            log.error("import-remote failed for %s: %s", entry.href, exc)
+        return {**base, "status": "error", "run_id": run_id, "error": str(exc)}
+
+
+def _summarize(url: str, mode: str, results: list[dict]) -> dict:
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    return {
+        "url": url,
+        "mode": mode,
+        "total": len(results),
+        "imported": counts.get("imported", 0),
+        "skipped_duplicate": counts.get("skipped-duplicate", 0),
+        "skipped_filtered": counts.get("skipped-filtered", 0),
+        "skipped_oversize": counts.get("skipped-oversize", 0),
+        "errors": counts.get("error", 0),
+        "files": results,
+    }

--- a/src/multicorpus_engine/remote/webdav.py
+++ b/src/multicorpus_engine/remote/webdav.py
@@ -1,0 +1,240 @@
+"""Minimal WebDAV client (stdlib only) for remote ingestion.
+
+Implements only the two operations the ingestion pipeline needs — list a
+collection (PROPFIND, ``Depth: 1``) and download a file (GET) — plus
+Authorization header construction. No third-party dependency: ``urllib`` for
+HTTP, ``defusedxml`` for parsing the multistatus body (XXE-safe).
+
+Validated target: ShareDocs Huma-Num (Nextcloud / SabreDAV). See
+docs/DESIGN_sharedocs_ingestion.md §3.
+"""
+
+from __future__ import annotations
+
+import base64
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import unquote, urljoin, urlsplit
+from urllib.request import Request, urlopen
+
+import defusedxml.ElementTree as ET
+
+_DAV = "DAV:"
+_CHUNK = 4 * 1024 * 1024  # 4 MiB — mirrors the importers' streaming reads
+DEFAULT_TIMEOUT = 30
+
+# Minimal PROPFIND body: request only the props we surface.
+_PROPFIND_BODY = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<d:propfind xmlns:d="DAV:"><d:prop>'
+    "<d:resourcetype/><d:getcontentlength/><d:getlastmodified/>"
+    "<d:getcontenttype/><d:getetag/>"
+    "</d:prop></d:propfind>"
+).encode("utf-8")
+
+
+class WebdavError(RuntimeError):
+    """Base error for WebDAV operations."""
+
+
+class WebdavAuthError(WebdavError):
+    """Authentication / authorization failure (HTTP 401 / 403)."""
+
+
+class WebdavNotFound(WebdavError):
+    """Resource not found (HTTP 404)."""
+
+
+class WebdavTooLarge(WebdavError):
+    """A file exceeds the configured size limit."""
+
+
+@dataclass
+class RemoteEntry:
+    """One child of a WebDAV collection."""
+
+    name: str
+    href: str  # absolute URL, resolved against the request URL
+    is_dir: bool
+    size: Optional[int]
+    modified: Optional[str]
+    content_type: Optional[str]
+
+
+def build_auth_header(
+    mode: str,
+    *,
+    user: Optional[str] = None,
+    password: Optional[str] = None,
+    token: Optional[str] = None,
+) -> dict:
+    """Build the Authorization header for *mode*.
+
+    ``mode`` ∈ {``"basic"``, ``"bearer"``, ``"anonymous"``}. Returns ``{}`` for
+    anonymous. Raises ``ValueError`` on missing credentials.
+    """
+    if mode == "anonymous":
+        return {}
+    if mode == "basic":
+        if not user or password is None:
+            raise ValueError("basic auth requires both a username and a password")
+        raw = f"{user}:{password}".encode("utf-8")
+        return {"Authorization": "Basic " + base64.b64encode(raw).decode("ascii")}
+    if mode == "bearer":
+        if not token:
+            raise ValueError("bearer auth requires a token")
+        return {"Authorization": f"Bearer {token}"}
+    raise ValueError(f"Unknown auth mode: {mode!r}")
+
+
+def _open(req: Request, timeout: int):
+    try:
+        return urlopen(req, timeout=timeout)
+    except HTTPError as exc:
+        if exc.code in (401, 403):
+            raise WebdavAuthError(
+                f"WebDAV authentication failed (HTTP {exc.code}) for {req.full_url}"
+            ) from exc
+        if exc.code == 404:
+            raise WebdavNotFound(f"WebDAV resource not found: {req.full_url}") from exc
+        raise WebdavError(f"WebDAV HTTP error {exc.code} for {req.full_url}") from exc
+    except (URLError, socket.timeout, TimeoutError) as exc:
+        raise WebdavError(f"WebDAV network error for {req.full_url}: {exc}") from exc
+
+
+def propfind(url: str, *, auth_header: dict, timeout: int = DEFAULT_TIMEOUT) -> list[RemoteEntry]:
+    """List the immediate children of the collection at *url* (``Depth: 1``).
+
+    The collection's own entry (the *self* entry) is excluded from the result.
+    Raises ``WebdavError`` (or a subclass) on failure, including when *url* points
+    to a file rather than a collection.
+    """
+    headers = {"Depth": "1", "Content-Type": "application/xml", **auth_header}
+    req = Request(url, method="PROPFIND", data=_PROPFIND_BODY, headers=headers)
+    with _open(req, timeout) as resp:
+        body = resp.read()
+    try:
+        root = ET.fromstring(body)
+    except Exception as exc:  # defusedxml raises various parse/entity errors
+        raise WebdavError(f"Invalid PROPFIND response from {url}: {exc}") from exc
+
+    self_path = urlsplit(url).path.rstrip("/")
+    self_is_dir: Optional[bool] = None
+    entries: list[RemoteEntry] = []
+
+    for resp_el in root.findall(f"{{{_DAV}}}response"):
+        href_el = resp_el.find(f"{{{_DAV}}}href")
+        if href_el is None or not href_el.text:
+            continue
+        href_raw = href_el.text.strip()
+        abs_url = urljoin(url, href_raw)
+        prop = _first_prop(resp_el)
+        is_dir = _is_collection(prop)
+
+        if urlsplit(abs_url).path.rstrip("/") == self_path:
+            self_is_dir = is_dir
+            continue
+
+        entries.append(
+            RemoteEntry(
+                name=_basename_from_href(href_raw),
+                href=abs_url,
+                is_dir=is_dir,
+                size=_int_or_none(_prop_text(prop, "getcontentlength")),
+                modified=_prop_text(prop, "getlastmodified"),
+                content_type=_prop_text(prop, "getcontenttype"),
+            )
+        )
+
+    if self_is_dir is False:
+        raise WebdavError(f"--url must point to a WebDAV collection (folder), not a file: {url}")
+    return entries
+
+
+def download(
+    url: str,
+    dest_path: str | Path,
+    *,
+    auth_header: dict,
+    max_bytes: Optional[int] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> int:
+    """Stream the file at *url* into *dest_path*. Returns the number of bytes written.
+
+    Raises ``WebdavTooLarge`` (without leaving a partial file) when the declared
+    or streamed size exceeds *max_bytes*.
+    """
+    dest_path = Path(dest_path)
+    req = Request(url, method="GET", headers=dict(auth_header))
+    with _open(req, timeout) as resp:
+        if max_bytes is not None:
+            declared = resp.headers.get("Content-Length")
+            if declared is not None:
+                try:
+                    if int(declared) > max_bytes:
+                        raise WebdavTooLarge(f"{url} is {declared} bytes (> {max_bytes})")
+                except ValueError:
+                    pass  # unparsable header — fall back to the streaming guard
+        written = 0
+        with open(dest_path, "wb") as fh:
+            while True:
+                chunk = resp.read(_CHUNK)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if max_bytes is not None and written > max_bytes:
+                    fh.close()
+                    dest_path.unlink(missing_ok=True)
+                    raise WebdavTooLarge(f"{url} exceeds {max_bytes} bytes")
+                fh.write(chunk)
+    return written
+
+
+# --- multistatus parsing helpers ------------------------------------------------
+
+def _first_prop(resp_el):
+    """Return the ``<prop>`` of the 200 propstat, else the first available one."""
+    fallback = None
+    for ps in resp_el.findall(f"{{{_DAV}}}propstat"):
+        prop = ps.find(f"{{{_DAV}}}prop")
+        if prop is None:
+            continue
+        status = ps.find(f"{{{_DAV}}}status")
+        if status is not None and status.text and " 200 " in status.text:
+            return prop
+        if fallback is None:
+            fallback = prop
+    return fallback
+
+
+def _is_collection(prop) -> bool:
+    if prop is None:
+        return False
+    rt = prop.find(f"{{{_DAV}}}resourcetype")
+    return rt is not None and rt.find(f"{{{_DAV}}}collection") is not None
+
+
+def _prop_text(prop, name: str) -> Optional[str]:
+    if prop is None:
+        return None
+    el = prop.find(f"{{{_DAV}}}{name}")
+    if el is None or el.text is None:
+        return None
+    return el.text.strip()
+
+
+def _int_or_none(s: Optional[str]) -> Optional[int]:
+    if s is None:
+        return None
+    try:
+        return int(s)
+    except ValueError:
+        return None
+
+
+def _basename_from_href(href: str) -> str:
+    path = unquote(urlsplit(href).path).rstrip("/")
+    return path.rsplit("/", 1)[-1] if path else ""

--- a/src/multicorpus_engine/remote/webdav.py
+++ b/src/multicorpus_engine/remote/webdav.py
@@ -12,6 +12,7 @@ docs/DESIGN_sharedocs_ingestion.md §3.
 from __future__ import annotations
 
 import base64
+import logging
 import socket
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,6 +26,8 @@ import defusedxml.ElementTree as ET
 _DAV = "DAV:"
 _CHUNK = 4 * 1024 * 1024  # 4 MiB — mirrors the importers' streaming reads
 DEFAULT_TIMEOUT = 30
+
+log = logging.getLogger(__name__)
 
 # Minimal PROPFIND body: request only the props we surface.
 _PROPFIND_BODY = (
@@ -105,6 +108,27 @@ def _open(req: Request, timeout: int):
         raise WebdavError(f"WebDAV network error for {req.full_url}: {exc}") from exc
 
 
+def _same_origin(base: str, other: str) -> bool:
+    """True if *other* shares *base*'s scheme/host/port (default ports normalized).
+
+    Used to refuse off-host hrefs before issuing any auth-bearing request, so a
+    malicious/compromised server cannot redirect the client (and its credentials)
+    to an arbitrary host.
+    """
+    b, o = urlsplit(base), urlsplit(other)
+
+    def _port(p) -> Optional[int]:
+        if p.port is not None:
+            return p.port
+        return {"https": 443, "http": 80}.get(p.scheme)
+
+    return (
+        b.scheme == o.scheme
+        and (b.hostname or "").lower() == (o.hostname or "").lower()
+        and _port(b) == _port(o)
+    )
+
+
 def propfind(url: str, *, auth_header: dict, timeout: int = DEFAULT_TIMEOUT) -> list[RemoteEntry]:
     """List the immediate children of the collection at *url* (``Depth: 1``).
 
@@ -131,6 +155,14 @@ def propfind(url: str, *, auth_header: dict, timeout: int = DEFAULT_TIMEOUT) -> 
             continue
         href_raw = href_el.text.strip()
         abs_url = urljoin(url, href_raw)
+        # Security: only ever follow same-origin hrefs. A malicious/compromised
+        # server could return an off-host href; downloading it would send the
+        # Authorization header to an arbitrary host (credential exfiltration) and
+        # could SSRF the client into internal networks. Off-origin entries are
+        # dropped here, before any auth-bearing GET in download().
+        if not _same_origin(url, abs_url):
+            log.warning("WebDAV: skipping off-origin href %r (base %s)", abs_url, url)
+            continue
         prop = _first_prop(resp_el)
         is_dir = _is_collection(prop)
 

--- a/tests/test_import_remote_batch.py
+++ b/tests/test_import_remote_batch.py
@@ -1,0 +1,153 @@
+"""Integration tests for the WebDAV batch ingestion orchestration.
+
+The WebDAV layer (propfind/download) is mocked; the import pipeline and a real
+temp SQLite DB run for real, so provenance and dedup are exercised end to end.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from multicorpus_engine.db.connection import get_connection
+from multicorpus_engine.db.migrations import apply_migrations
+from multicorpus_engine.remote import ingest, webdav
+
+_MIGRATIONS = Path(__file__).parent.parent / "migrations"
+_BASE = "https://dav.example/folder/"
+
+
+def _make_docx_bytes(paragraphs: list[str]) -> bytes:
+    import docx
+
+    d = docx.Document()
+    for p in paragraphs:
+        d.add_paragraph(p)
+    buf = io.BytesIO()
+    d.save(buf)
+    return buf.getvalue()
+
+
+def _entry(name: str, size: int = 1000, is_dir: bool = False) -> webdav.RemoteEntry:
+    return webdav.RemoteEntry(
+        name=name, href=_BASE + name, is_dir=is_dir,
+        size=size, modified=None, content_type=None,
+    )
+
+
+def _download_from(payloads: dict[str, bytes]):
+    def _fake(url, dest_path, *, auth_header, max_bytes=None, timeout=30):
+        data = payloads[url]
+        if max_bytes is not None and len(data) > max_bytes:
+            raise webdav.WebdavTooLarge(url)
+        Path(dest_path).write_bytes(data)
+        return len(data)
+    return _fake
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    db_path = tmp_path / "corpus.db"
+    conn = get_connection(db_path)
+    apply_migrations(conn, migrations_dir=_MIGRATIONS)
+    return conn, db_path
+
+
+def _run(conn, db_path, entries, payloads, **kwargs):
+    with mock.patch.object(ingest.webdav, "propfind", return_value=entries), \
+         mock.patch.object(ingest.webdav, "download", _download_from(payloads)):
+        return ingest.ingest_remote_folder(
+            conn, db_path, url=_BASE, mode="docx_numbered_lines",
+            language="fr", auth_header={}, **kwargs,
+        )
+
+
+def test_filters_non_matching_and_imports(db):
+    conn, db_path = db
+    a = _make_docx_bytes(["[1] Bonjour.", "[2] Monde."])
+    b = _make_docx_bytes(["[1] Autre texte."])
+    entries = [_entry("a.docx", len(a)), _entry("b.docx", len(b)), _entry("note.pdf", 10)]
+    payloads = {_BASE + "a.docx": a, _BASE + "b.docx": b}
+
+    report = _run(conn, db_path, entries, payloads)
+
+    assert report["total"] == 3
+    assert report["imported"] == 2
+    assert report["skipped_filtered"] == 1  # the .pdf
+    assert report["errors"] == 0
+
+    # Provenance: source_path is the remote URL, not the temp path.
+    paths = [r["source_path"] for r in conn.execute("SELECT source_path FROM documents").fetchall()]
+    assert sorted(paths) == [_BASE + "a.docx", _BASE + "b.docx"]
+
+
+def test_rerun_is_idempotent_via_dedup(db):
+    conn, db_path = db
+    a = _make_docx_bytes(["[1] Bonjour.", "[2] Monde."])
+    entries = [_entry("a.docx", len(a))]
+    payloads = {_BASE + "a.docx": a}
+
+    first = _run(conn, db_path, entries, payloads)
+    assert first["imported"] == 1
+
+    second = _run(conn, db_path, entries, payloads)
+    assert second["imported"] == 0
+    assert second["skipped_duplicate"] == 1
+    # No second document created.
+    assert conn.execute("SELECT COUNT(*) AS c FROM documents").fetchone()["c"] == 1
+
+
+def test_per_file_download_error_does_not_abort_batch(db):
+    conn, db_path = db
+    good = _make_docx_bytes(["[1] Bonjour."])
+    entries = [_entry("bad.docx", 500), _entry("good.docx", len(good))]
+    payloads = {_BASE + "good.docx": good}  # bad.docx absent → KeyError-free explicit raise
+
+    def _dl(url, dest_path, *, auth_header, max_bytes=None, timeout=30):
+        if url.endswith("bad.docx"):
+            raise webdav.WebdavError("simulated download failure")
+        Path(dest_path).write_bytes(payloads[url])
+        return len(payloads[url])
+
+    with mock.patch.object(ingest.webdav, "propfind", return_value=entries), \
+         mock.patch.object(ingest.webdav, "download", _dl):
+        report = ingest.ingest_remote_folder(
+            conn, db_path, url=_BASE, mode="docx_numbered_lines",
+            language="fr", auth_header={},
+        )
+
+    assert report["imported"] == 1
+    assert report["errors"] == 1
+    statuses = {r["name"]: r["status"] for r in report["files"]}
+    assert statuses["bad.docx"] == "error"
+    assert statuses["good.docx"] == "imported"
+
+
+def test_oversize_is_skipped_without_download(db):
+    conn, db_path = db
+    entries = [_entry("big.docx", size=10 * 1024 * 1024)]  # 10 MiB declared
+
+    download = mock.Mock(side_effect=AssertionError("download must not be called for oversize"))
+    with mock.patch.object(ingest.webdav, "propfind", return_value=entries), \
+         mock.patch.object(ingest.webdav, "download", download):
+        report = ingest.ingest_remote_folder(
+            conn, db_path, url=_BASE, mode="docx_numbered_lines",
+            language="fr", auth_header={}, max_file_mb=1,
+        )
+
+    assert report["skipped_oversize"] == 1
+    assert report["imported"] == 0
+    download.assert_not_called()
+
+
+def test_blocking_propfind_error_propagates(db):
+    conn, db_path = db
+    with mock.patch.object(ingest.webdav, "propfind", side_effect=webdav.WebdavAuthError("401")):
+        with pytest.raises(webdav.WebdavAuthError):
+            ingest.ingest_remote_folder(
+                conn, db_path, url=_BASE, mode="docx_numbered_lines",
+                language="fr", auth_header={},
+            )

--- a/tests/test_webdav_client.py
+++ b/tests/test_webdav_client.py
@@ -127,6 +127,38 @@ def test_propfind_lists_children_excluding_self():
     assert by_name["sub"].is_dir is True
 
 
+def test_propfind_excludes_off_origin_hrefs():
+    # A malicious/compromised server returns an off-host href. It must NOT become
+    # a downloadable entry — otherwise download() would send the Authorization
+    # header to attacker.example (credential exfiltration) / SSRF.
+    body = b"""<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/files/user/folder/safe.docx</d:href>
+    <d:propstat><d:prop><d:resourcetype/></d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>https://attacker.example/steal.docx</d:href>
+    <d:propstat><d:prop><d:resourcetype/></d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>http://dav.example/remote.php/dav/files/user/folder/downgrade.docx</d:href>
+    <d:propstat><d:prop><d:resourcetype/></d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+</d:multistatus>"""
+    with mock.patch.object(webdav, "urlopen", lambda req, timeout=None: _FakeResp(body)):
+        entries = webdav.propfind(_URL, auth_header={"Authorization": "Basic x"})
+
+    # Only the same-origin (https://dav.example) file survives; the off-host and
+    # the scheme-downgraded (http) entries are dropped.
+    assert [e.name for e in entries] == ["safe.docx"]
+    assert all(webdav.urlsplit(e.href).hostname == "dav.example" for e in entries)
+    assert all(webdav.urlsplit(e.href).scheme == "https" for e in entries)
+
+
 def test_propfind_on_a_file_raises():
     # A PROPFIND whose only (self) entry is not a collection → url is a file.
     body = b"""<?xml version="1.0"?>

--- a/tests/test_webdav_client.py
+++ b/tests/test_webdav_client.py
@@ -1,0 +1,199 @@
+"""Unit tests for the stdlib WebDAV client (multicorpus_engine.remote.webdav).
+
+Network is mocked at ``urlopen``; no real server is contacted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from multicorpus_engine.remote import webdav
+
+
+# A SabreDAV/Nextcloud-style 207 multistatus: the collection itself (self),
+# one file, and one subfolder. hrefs are server-absolute and percent-encoded.
+_MULTISTATUS = b"""<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/files/user/folder/</d:href>
+    <d:propstat>
+      <d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/files/user/folder/Le%20texte.docx</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:getcontentlength>1234</d:getcontentlength>
+        <d:getlastmodified>Mon, 01 Jun 2026 10:00:00 GMT</d:getlastmodified>
+        <d:getcontenttype>application/vnd.openxmlformats</d:getcontenttype>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/files/user/folder/sub/</d:href>
+    <d:propstat>
+      <d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>
+"""
+
+_URL = "https://dav.example/remote.php/dav/files/user/folder/"
+
+
+class _FakeResp:
+    """Minimal context-manager response with chunked read + headers."""
+
+    def __init__(self, body: bytes = b"", headers: dict | None = None):
+        self._body = body
+        self.headers = headers or {}
+
+    def read(self, n: int = -1) -> bytes:
+        if n is None or n < 0:
+            data, self._body = self._body, b""
+            return data
+        data, self._body = self._body[:n], self._body[n:]
+        return data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+# --- auth header construction ---------------------------------------------------
+
+def test_build_auth_header_basic():
+    h = webdav.build_auth_header("basic", user="alice", password="secret")
+    assert h["Authorization"].startswith("Basic ")
+
+
+def test_build_auth_header_bearer():
+    assert webdav.build_auth_header("bearer", token="tok") == {"Authorization": "Bearer tok"}
+
+
+def test_build_auth_header_anonymous():
+    assert webdav.build_auth_header("anonymous") == {}
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"user": "alice"},          # basic without password
+    {"password": "x"},          # basic without user
+])
+def test_build_auth_header_basic_incomplete(kwargs):
+    with pytest.raises(ValueError):
+        webdav.build_auth_header("basic", **kwargs)
+
+
+def test_build_auth_header_bearer_missing_token():
+    with pytest.raises(ValueError):
+        webdav.build_auth_header("bearer")
+
+
+# --- propfind -------------------------------------------------------------------
+
+def test_propfind_lists_children_excluding_self():
+    captured = {}
+
+    def _fake_urlopen(req, timeout=None):
+        captured["method"] = req.method
+        return _FakeResp(_MULTISTATUS)
+
+    with mock.patch.object(webdav, "urlopen", _fake_urlopen):
+        entries = webdav.propfind(_URL, auth_header={})
+
+    assert captured["method"] == "PROPFIND"
+    # self collection excluded → file + subfolder remain
+    assert len(entries) == 2
+    by_name = {e.name: e for e in entries}
+
+    docx = by_name["Le texte.docx"]  # percent-decoded name
+    assert docx.is_dir is False
+    assert docx.size == 1234
+    assert docx.content_type == "application/vnd.openxmlformats"
+    # href resolved to an absolute URL against the request
+    assert docx.href == "https://dav.example/remote.php/dav/files/user/folder/Le%20texte.docx"
+
+    assert by_name["sub"].is_dir is True
+
+
+def test_propfind_on_a_file_raises():
+    # A PROPFIND whose only (self) entry is not a collection → url is a file.
+    body = b"""<?xml version="1.0"?>
+    <d:multistatus xmlns:d="DAV:">
+      <d:response>
+        <d:href>/remote.php/dav/files/user/folder/a.docx</d:href>
+        <d:propstat>
+          <d:prop><d:resourcetype/><d:getcontentlength>10</d:getcontentlength></d:prop>
+          <d:status>HTTP/1.1 200 OK</d:status>
+        </d:propstat>
+      </d:response>
+    </d:multistatus>"""
+    url = "https://dav.example/remote.php/dav/files/user/folder/a.docx"
+    with mock.patch.object(webdav, "urlopen", lambda req, timeout=None: _FakeResp(body)):
+        with pytest.raises(webdav.WebdavError):
+            webdav.propfind(url, auth_header={})
+
+
+# --- error mapping --------------------------------------------------------------
+
+@pytest.mark.parametrize("code,exc_type", [
+    (401, webdav.WebdavAuthError),
+    (403, webdav.WebdavAuthError),
+    (404, webdav.WebdavNotFound),
+    (500, webdav.WebdavError),
+])
+def test_http_errors_are_mapped(code, exc_type):
+    def _raise(req, timeout=None):
+        raise HTTPError(req.full_url, code, "boom", {}, None)
+
+    with mock.patch.object(webdav, "urlopen", _raise):
+        with pytest.raises(exc_type):
+            webdav.propfind(_URL, auth_header={})
+
+
+def test_network_error_is_mapped():
+    def _raise(req, timeout=None):
+        raise URLError("no route")
+
+    with mock.patch.object(webdav, "urlopen", _raise):
+        with pytest.raises(webdav.WebdavError):
+            webdav.propfind(_URL, auth_header={})
+
+
+# --- download -------------------------------------------------------------------
+
+def test_download_writes_file(tmp_path: Path):
+    dest = tmp_path / "out.bin"
+    payload = b"hello world"
+    with mock.patch.object(webdav, "urlopen", lambda req, timeout=None: _FakeResp(payload, {"Content-Length": str(len(payload))})):
+        written = webdav.download("https://dav.example/f", dest, auth_header={})
+    assert written == len(payload)
+    assert dest.read_bytes() == payload
+
+
+def test_download_rejects_oversize_declared(tmp_path: Path):
+    dest = tmp_path / "out.bin"
+    with mock.patch.object(webdav, "urlopen", lambda req, timeout=None: _FakeResp(b"x" * 100, {"Content-Length": "100"})):
+        with pytest.raises(webdav.WebdavTooLarge):
+            webdav.download("https://dav.example/f", dest, auth_header={}, max_bytes=10)
+    assert not dest.exists()
+
+
+def test_download_rejects_oversize_streamed_without_header(tmp_path: Path):
+    dest = tmp_path / "out.bin"
+    # No Content-Length → the streaming guard must catch it and remove the partial.
+    with mock.patch.object(webdav, "urlopen", lambda req, timeout=None: _FakeResp(b"x" * 100, {})):
+        with pytest.raises(webdav.WebdavTooLarge):
+            webdav.download("https://dav.example/f", dest, auth_header={}, max_bytes=10)
+    assert not dest.exists()


### PR DESCRIPTION
**Fondation de P0-1** : cette PR land le travail ShareDocs P1 (resté non mergé depuis avant la session d'audit), dont le routeur **`importers/dispatch.py`** — la source unique mode→importer sur laquelle le `/import` du sidecar devra converger (P0-1 tranche-1).

## Contenu (P1)
- `remote/webdav.py` — client WebDAV stdlib (PROPFIND/GET), pas de nouvelle dépendance.
- `remote/ingest.py` — orchestration batch d'ingestion.
- `importers/dispatch.py` — routeur mode→importer (utilisé par la CLI ; futur point de convergence du sidecar).
- `cli.py` — sous-commande `import-remote` + `cmd_import` routé via `dispatch_import`.
- Tests : `test_webdav_client.py`, `test_import_remote_batch.py` + docs (DESIGN + tickets P1/P2/P3).

## Intégration sur le `development` actuel
- Branche basée sur `373524b` (avant l'audit) → **merge de `development` (17 commits) effectué, sans conflit**.
- **ruff** : vert sur l'ensemble (code ShareDocs ruff-clean).
- **Tests** : 439 non-sidecar passent (dont les 2 fichiers ShareDocs).
- **Couverture** : `remote/webdav.py` 90 %, `remote/ingest.py` 91 % → la couverture globale reste ≥ 60 (la CI donne le chiffre exact). `cli.py` 0 % = artefact subprocess pré-existant, pas une régression.
- ShareDocs P1 **ne touche pas `sidecar.py`** → contrat OpenAPI / tests sidecar intacts.

## Revue conseillée
Code feature (WebDAV + credentials). Vérifier la posture creds du DESIGN : reçus en body sur loopback, **jamais persistés** (db/runs.params/logs/télémétrie) — cf. `docs/DESIGN_sharedocs_ingestion.md` §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)