### PR TITLE
refactor(P0-1): close A-02 — shared parse layer for all 7 importers + preview dedup

### DIFF
--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -31,6 +31,8 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | Q-01 | 🟠 | P0-2 | ✅ corrigé | `[tool.ruff]` (E4/E7/E9/F, E741 ignoré) + job CI `lint` ; 57 violations résorbées (46 autofix, 5 vars, 1 dead). `1b12520` |
 | T-01 | 🔴 | P0-2 | ✅ corrigé | Gate `--cov-fail-under=60` dans le step pytest CI (ratcheté depuis 35 ; couverture réelle CI = 61,94 %). `1b12520` |
 | N-01 | 🟠 | P0-2 | ✅ corrigé | `dependabot.yml` étendu à pip/npm/cargo (4 apps + `src-tauri`), groupé hebdo. `1b12520` |
+| A-02 | 🟠 | P0-1 | ✅ corrigé | `/import/preview` ne réimplémente plus les importers : chaque mode passe par `parse_<mode>() -> ParsedDoc` + `to_preview()` (txt/docx×2/odt×2/tei), preview CoNLL-U *lenient* déplacé dans `conllu.preview_conllu`. `sidecar.py` −142 l. Corrige 3 divergences preview↔import (strip préfixe docx, fallback ext_id TEI, preview ODT cassé). PR #47, tests `test_parse_layer.py` (équivalence preview==import) |
+| Q-03 | 🟡 | — | ✅ corrigé | `file_sha256` unique dans `parsed.py` ; les 7 importers l'utilisent (suppression des 5 `_compute_file_hash` + 2 cross-imports docx→odt). PR #47 |
 | — | — | — | ✅ bonus | CI déclenchée aussi sur `development` (les gates ne tiraient que sur `main`). `1b12520` |
 | D-04 | 🟡 | P1-7 | ✅ corrigé | **Ce fichier** (vue inverse finding→statut→commit) |
 | A-05 | — | — | ❌ retiré | Réfuté en passe 2 : les index secondaires existent (`003_alignment.sql`, `012_tokens.sql`) |
@@ -40,11 +42,9 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | ID | Sév | Prio | Statut | Constat (résumé) |
 |----|-----|------|--------|------------------|
 | A-01 | 🔴 | P0-1 | ⬜ ouvert | `sidecar.py` monolithe (9 961 l., 93 handlers, pas de couche services) |
-| A-02 | 🟠 | P0-1 | 🟦 partiel | `/import/preview` réimplémente les importers (`sidecar.py:2458`). Le router `dispatch_import` (branche `feat/sharedocs-ingestion-p1`) unifie l'**import** mais pas le **preview** |
 | A-03 | 🟠 | P0-1 | ⬜ ouvert | 66 blocs de validation manuelle (pas de validateur de schéma) |
 | A-04 | 🟡 | P2-13 | ⬜ ouvert | Attributs dynamiques non typés sur `HTTPServer` |
 | Q-02 | 🟠 | P0-1 | ⬜ ouvert | Fonctions géantes ; `_build_hits` vs `_build_hits_regex` (~70 l. dupliquées) |
-| Q-03 | 🟡 | — | ⬜ ouvert | `_compute_file_hash` redéfini dans 5 importers ; dup DOCX/ODT |
 | Q-04 | 🟡 | P2-13 | ⬜ ouvert | Typage hétérogène ; pas de TypedDict pour les shapes de contrat |
 | Q-05 | 🟡 | — | ⬜ ouvert | Matcher CQL : pas de cap global documenté (gardes présentes) |
 | T-02 | 🟠 | P0-3 | ⬜ ouvert | Branches cœur `telemetry.py` / `curation.py` sans test direct |

--- a/src/multicorpus_engine/importers/conllu.py
+++ b/src/multicorpus_engine/importers/conllu.py
@@ -111,6 +111,101 @@ def _parse_conllu(text: str) -> tuple[list[dict], dict[str, int]]:
     return sentences, stats
 
 
+def preview_conllu(path: str | Path, limit: int) -> dict:
+    """Lenient read-only scan of a CoNLL-U file for ``/import/preview`` (A-02).
+
+    Unlike the strict :func:`import_conllu` / :func:`_parse_conllu` — which raise on
+    a malformed 10-column row — the preview COUNTS malformed lines and never raises,
+    so the UI can surface problems before the user commits to an import. Decoding is
+    also lenient (utf-8-sig, then latin-1) where the importer would reject non-UTF-8.
+
+    Returns the ``conllu_stats`` dict: ``sentences``, ``tokens``, ``skipped_ranges``,
+    ``skipped_empty_nodes``, ``malformed_lines`` and ``sample_rows[:limit]`` (each
+    ``{sent, id, form, lemma, upos}``).
+    """
+    path = Path(path)
+    raw_bytes = path.read_bytes()
+    try:
+        text = raw_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        text = raw_bytes.decode("latin-1")
+
+    tokens_total = 0
+    skipped_ranges = 0
+    skipped_empty_nodes = 0
+    malformed_lines = 0
+
+    # First pass: token + skip counters only. Sentence counting happens below.
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            continue
+        cols = raw_line.split("\t")
+        if len(cols) != 10:
+            malformed_lines += 1
+            continue
+        token_id = cols[0].strip()
+        if "-" in token_id:
+            skipped_ranges += 1
+            continue
+        if "." in token_id:
+            skipped_empty_nodes += 1
+            continue
+        tokens_total += 1
+
+    # Second pass: sentences (blank-line delimited blocks with tokens) + sample.
+    sentences_total = 0
+    in_sentence = False
+    has_tokens = False
+    sample_sent = 0
+    sample_rows: list[dict] = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if has_tokens:
+                sentences_total += 1
+            in_sentence = False
+            has_tokens = False
+            continue
+        if line.startswith("#"):
+            if not in_sentence:
+                in_sentence = True
+                sample_sent += 1
+            continue
+        cols = raw_line.split("\t")
+        if len(cols) != 10:
+            continue
+        token_id = cols[0].strip()
+        if "-" in token_id or "." in token_id:
+            continue
+        has_tokens = True
+        if len(sample_rows) < limit:
+            lemma = cols[2].strip()
+            upos = cols[3].strip()
+            sample_rows.append({
+                "sent": sample_sent,
+                "id": token_id,
+                "form": cols[1].strip(),
+                "lemma": "—" if lemma == "_" else lemma,
+                "upos": "—" if upos == "_" else upos,
+            })
+
+    if has_tokens:
+        sentences_total += 1
+
+    return {
+        "sentences": sentences_total,
+        "tokens": tokens_total,
+        "skipped_ranges": skipped_ranges,
+        "skipped_empty_nodes": skipped_empty_nodes,
+        "malformed_lines": malformed_lines,
+        "sample_rows": sample_rows,
+    }
+
+
 def import_conllu(
     conn: sqlite3.Connection,
     path: str | Path,

--- a/src/multicorpus_engine/importers/conllu.py
+++ b/src/multicorpus_engine/importers/conllu.py
@@ -7,7 +7,6 @@ Imports a CoNLL-U file into:
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import sqlite3
@@ -17,16 +16,9 @@ from typing import Optional
 from ..unicode_policy import normalize
 from .docx_numbered_lines import ImportReport, _analyze_external_ids
 from .import_guard import assert_not_duplicate_import
+from .parsed import file_sha256
 
 logger = logging.getLogger(__name__)
-
-
-def _compute_file_hash(path: Path) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(65536), b""):
-            h.update(chunk)
-    return h.hexdigest()
 
 
 def _clean_field(value: str) -> str | None:
@@ -146,7 +138,7 @@ def import_conllu(
     _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
     if path.stat().st_size > _MAX_FILE_BYTES:
         raise ValueError(f"CoNLL-U file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
-    source_hash = _compute_file_hash(path)
+    source_hash = file_sha256(path)
     assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
 
     raw_bytes = path.read_bytes()

--- a/src/multicorpus_engine/importers/docx_numbered_lines.py
+++ b/src/multicorpus_engine/importers/docx_numbered_lines.py
@@ -14,7 +14,6 @@ Rules (see docs/DECISIONS.md ADR-001, ADR-002, ADR-003):
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import re
@@ -25,6 +24,7 @@ from typing import Optional
 
 from ..unicode_policy import count_sep, normalize
 from .import_guard import assert_not_duplicate_import
+from .parsed import ParsedDoc, ParsedUnit, file_sha256
 from .rich_text import para_to_rich_text
 
 _NUMBERED_RE = re.compile(r"^\[\s*(\d+)\s*\]\s*(.+)$", re.DOTALL)
@@ -68,14 +68,6 @@ class ImportReport:
             "rows_skipped_short": self.rows_skipped_short,
             "nested_tables_skipped": self.nested_tables_skipped,
         }
-
-
-def _compute_file_hash(path: Path) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(65536), b""):
-            h.update(chunk)
-    return h.hexdigest()
 
 
 def _paragraph_to_unit(
@@ -172,31 +164,17 @@ def _analyze_external_ids(external_ids: list[int]) -> tuple[list[int], list[int]
     return duplicates, holes, non_monotonic
 
 
-def import_docx_numbered_lines(
-    conn: sqlite3.Connection,
+def parse_docx_numbered_lines(
     path: str | Path,
-    language: str,
-    title: Optional[str] = None,
-    doc_role: str = "standalone",
-    resource_type: Optional[str] = None,
-    run_id: Optional[str] = None,
-    run_logger: Optional[logging.Logger] = None,
-    check_filename: bool = False,
     column_index: Optional[int] = None,
-) -> ImportReport:
-    """Import a DOCX file using the numbered-lines convention.
+    run_logger: Optional[logging.Logger] = None,
+) -> ParsedDoc:
+    """Parse a DOCX (numbered-lines convention) into units WITHOUT touching the DB.
 
-    Creates one row in `documents` and one row per paragraph in `units`.
-    Returns an ImportReport with diagnostics.
-
-    ``column_index`` controls table handling:
-      - ``None`` (default) → tables are skipped entirely (legacy behavior).
-      - ``>= 1`` → walk the body in document order; for each table, extract
-        the cell at column ``column_index`` (1-based) and flatten its
-        paragraphs. Pathological cases (table with fewer columns, merged
-        cells coming from a lower column, nested sub-tables) are surfaced
-        in ``ImportReport.warnings`` / new counters instead of failing
-        silently.
+    Shared by ``import_docx_numbered_lines`` (write path) and the sidecar
+    ``/import/preview`` so the parsing — including the column_index table walk and
+    its vMerge dedup — lives in exactly one place (A-02). Raises
+    ``ImportError`` / ``FileNotFoundError`` / ``ValueError`` like the importer did.
     """
     try:
         import docx  # python-docx
@@ -212,32 +190,21 @@ def import_docx_numbered_lines(
         raise ValueError(f"DOCX file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
 
     log = run_logger or logger
-    log.info("Starting import of %s (mode=docx_numbered_lines)", path)
-
-    source_hash = _compute_file_hash(path)
-    assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
-    doc_title = title or path.stem
-    utcnow = __import__("datetime").datetime.now(
-        __import__("datetime").timezone.utc
-    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    source_hash = file_sha256(path)
 
     # Validate column_index early so the user gets a clear error.
     if column_index is not None and column_index < 1:
         raise ValueError(f"column_index must be >= 1 (got {column_index})")
 
-    # Parse DOCX before opening the transaction (pure I/O, no DB writes yet)
     document = docx.Document(str(path))
 
-    external_ids: list[int] = []
-    # (unit_type, n, ext_id, text_raw, text_norm, meta) — doc_id added after INSERT
+    # (unit_type, n, ext_id, text_raw, text_norm, meta) — doc_id added by the writer.
     units_parsed: list[tuple] = []
 
     # Per-table extraction counters (renseignés seulement quand column_index est set).
     tables_processed = 0
     rows_skipped_short = 0
     nested_tables_skipped = 0
-    # Pour le warning « colonne sans [N] dominante » — on suit séparément les
-    # paragraphes extraits depuis les cellules de la colonne demandée.
     col_paragraphs_total = 0
     col_paragraphs_line = 0
 
@@ -247,10 +214,7 @@ def import_docx_numbered_lines(
         nonlocal n
         n += 1
         # Override the n placeholder produced by the helper with the live counter.
-        unit = (unit[0], n, *unit[2:])
-        units_parsed.append(unit)
-        if unit[0] == "line":
-            external_ids.append(unit[2])
+        units_parsed.append((unit[0], n, *unit[2:]))
 
     if column_index is None:
         # Legacy path — tables are skipped (python-docx Document.paragraphs
@@ -332,6 +296,81 @@ def import_docx_numbered_lines(
                             tables_processed, row_idx + 1, column_index,
                             n, unit[0],
                         )
+
+    units = [
+        ParsedUnit(
+            n=u[1], unit_type=u[0], text_raw=u[3], text_norm=u[4],
+            external_id=u[2], meta_json=u[5],
+        )
+        for u in units_parsed
+    ]
+    return ParsedDoc(
+        units=units,
+        doc_meta={},
+        source_hash=source_hash,
+        stats={
+            "tables_processed": tables_processed,
+            "rows_skipped_short": rows_skipped_short,
+            "nested_tables_skipped": nested_tables_skipped,
+            "col_paragraphs_total": col_paragraphs_total,
+            "col_paragraphs_line": col_paragraphs_line,
+        },
+    )
+
+
+def import_docx_numbered_lines(
+    conn: sqlite3.Connection,
+    path: str | Path,
+    language: str,
+    title: Optional[str] = None,
+    doc_role: str = "standalone",
+    resource_type: Optional[str] = None,
+    run_id: Optional[str] = None,
+    run_logger: Optional[logging.Logger] = None,
+    check_filename: bool = False,
+    column_index: Optional[int] = None,
+) -> ImportReport:
+    """Import a DOCX file using the numbered-lines convention.
+
+    Creates one row in `documents` and one row per paragraph in `units`.
+    Returns an ImportReport with diagnostics.
+
+    ``column_index`` controls table handling:
+      - ``None`` (default) → tables are skipped entirely (legacy behavior).
+      - ``>= 1`` → walk the body in document order; for each table, extract
+        the cell at column ``column_index`` (1-based) and flatten its
+        paragraphs. Pathological cases (table with fewer columns, merged
+        cells coming from a lower column, nested sub-tables) are surfaced
+        in ``ImportReport.warnings`` / new counters instead of failing
+        silently.
+    """
+    path = Path(path)
+    log = run_logger or logger
+    log.info("Starting import of %s (mode=docx_numbered_lines)", path)
+
+    parsed = parse_docx_numbered_lines(path, column_index=column_index, run_logger=run_logger)
+    assert_not_duplicate_import(conn, path, parsed.source_hash, check_filename=check_filename)
+    source_hash = parsed.source_hash
+    doc_title = title or path.stem
+    utcnow = __import__("datetime").datetime.now(
+        __import__("datetime").timezone.utc
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Project parsed units onto DB-insert tuples (doc_id added below) + diagnostics.
+    units_parsed: list[tuple] = [
+        (u.unit_type, u.n, u.external_id, u.text_raw, u.text_norm, u.meta_json)
+        for u in parsed.units
+    ]
+    external_ids: list[int] = [
+        u.external_id for u in parsed.units
+        if u.unit_type == "line" and u.external_id is not None
+    ]
+    s = parsed.stats
+    tables_processed = s["tables_processed"]
+    rows_skipped_short = s["rows_skipped_short"]
+    nested_tables_skipped = s["nested_tables_skipped"]
+    col_paragraphs_total = s["col_paragraphs_total"]
+    col_paragraphs_line = s["col_paragraphs_line"]
 
     # Single transaction: document record + units
     try:

--- a/src/multicorpus_engine/importers/docx_paragraphs.py
+++ b/src/multicorpus_engine/importers/docx_paragraphs.py
@@ -11,7 +11,6 @@ See docs/DECISIONS.md ADR-012.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import sqlite3
@@ -21,17 +20,73 @@ from typing import Optional
 from ..unicode_policy import count_sep, normalize
 from .docx_numbered_lines import ImportReport
 from .import_guard import assert_not_duplicate_import
+from .parsed import ParsedDoc, ParsedUnit, file_sha256
 from .rich_text import para_to_rich_text
 
 logger = logging.getLogger(__name__)
 
 
-def _compute_file_hash(path: Path) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(65536), b""):
-            h.update(chunk)
-    return h.hexdigest()
+def parse_docx_paragraphs(
+    path: str | Path,
+    run_logger: Optional[logging.Logger] = None,
+) -> ParsedDoc:
+    """Parse a DOCX into one line unit per non-empty paragraph, WITHOUT touching
+    the DB. Shared by ``import_docx_paragraphs`` and ``/import/preview`` (A-02).
+    Sequential position (1-based) is both n and external_id; Heading-styled
+    paragraphs get unit_role="intertitre" + meta heading_level.
+    """
+    try:
+        import docx  # python-docx
+    except ImportError as exc:
+        raise ImportError("python-docx is required: pip install python-docx") from exc
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"DOCX file not found: {path}")
+
+    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
+    if path.stat().st_size > _MAX_FILE_BYTES:
+        raise ValueError(f"DOCX file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
+
+    log = run_logger or logger
+    source_hash = file_sha256(path)
+    document = docx.Document(str(path))
+
+    # First pass: collect paragraphs and detect headings.
+    para_data: list[tuple[str, int | None]] = []
+    for para in document.paragraphs:
+        text_raw = para_to_rich_text(para)
+        if not normalize(text_raw).strip():
+            continue
+        heading_level: int | None = None
+        style_name = (para.style.name or "") if para.style else ""
+        if style_name.startswith("Heading"):
+            try:
+                heading_level = int(style_name.split()[-1])
+            except ValueError:
+                heading_level = 1
+        para_data.append((text_raw, heading_level))
+
+    units: list[ParsedUnit] = []
+    n = 0
+    for text_raw, heading_level in para_data:
+        n += 1
+        text_norm = normalize(text_raw)
+        sep_count = count_sep(text_raw)
+        meta_dict: dict = {}
+        if sep_count > 0:
+            meta_dict["sep_count"] = sep_count
+        if heading_level is not None:
+            meta_dict["heading_level"] = heading_level
+        meta = json.dumps(meta_dict) if meta_dict else None
+        unit_role = "intertitre" if heading_level is not None else None
+        units.append(ParsedUnit(
+            n=n, unit_type="line", text_raw=text_raw, text_norm=text_norm,
+            external_id=n, meta_json=meta, unit_role=unit_role,
+        ))
+        log.debug("Para n=%d type=line role=%s", n, unit_role)
+
+    return ParsedDoc(units=units, doc_meta={}, source_hash=source_hash)
 
 
 def import_docx_paragraphs(
@@ -53,63 +108,24 @@ def import_docx_paragraphs(
 
     Returns an ImportReport. units_structure is always 0 (all units are lines).
     """
-    try:
-        import docx  # python-docx
-    except ImportError as exc:
-        raise ImportError("python-docx is required: pip install python-docx") from exc
-
     path = Path(path)
-    if not path.exists():
-        raise FileNotFoundError(f"DOCX file not found: {path}")
-
-    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
-    if path.stat().st_size > _MAX_FILE_BYTES:
-        raise ValueError(f"DOCX file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
-
     log = run_logger or logger
     log.info("Starting import of %s (mode=docx_paragraphs)", path)
 
-    source_hash = _compute_file_hash(path)
-    assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
+    parsed = parse_docx_paragraphs(path, run_logger=run_logger)
+    assert_not_duplicate_import(conn, path, parsed.source_hash, check_filename=check_filename)
+    source_hash = parsed.source_hash
     doc_title = title or path.stem
     utcnow = __import__("datetime").datetime.now(
         __import__("datetime").timezone.utc
     ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    # Parse DOCX before opening the transaction (pure I/O, no DB writes yet)
-    document = docx.Document(str(path))
-
-    # First pass: collect paragraphs and detect headings
-    para_data: list[tuple[str, int | None]] = []
-    for para in document.paragraphs:
-        text_raw = para_to_rich_text(para)
-        if not normalize(text_raw).strip():
-            continue
-        heading_level: int | None = None
-        style_name = (para.style.name or "") if para.style else ""
-        if style_name.startswith("Heading"):
-            try:
-                heading_level = int(style_name.split()[-1])
-            except ValueError:
-                heading_level = 1
-        para_data.append((text_raw, heading_level))
-
-    # (unit_type, n, ext_id, text_raw, text_norm, meta, unit_role) — doc_id added after INSERT
-    units_parsed: list[tuple] = []
-    n = 0
-    for text_raw, heading_level in para_data:
-        n += 1
-        text_norm = normalize(text_raw)
-        sep_count = count_sep(text_raw)
-        meta_dict: dict = {}
-        if sep_count > 0:
-            meta_dict["sep_count"] = sep_count
-        if heading_level is not None:
-            meta_dict["heading_level"] = heading_level
-        meta = json.dumps(meta_dict) if meta_dict else None
-        unit_role = "intertitre" if heading_level is not None else None
-        units_parsed.append(("line", n, n, text_raw, text_norm, meta, unit_role))
-        log.debug("Para n=%d type=line role=%s", n, unit_role)
+    units_parsed: list[tuple] = [
+        (u.unit_type, u.n, u.external_id, u.text_raw, u.text_norm, u.meta_json, u.unit_role)
+        for u in parsed.units
+    ]
+    has_headings = any(u.unit_role == "intertitre" for u in parsed.units)
+    n_headings = sum(1 for u in parsed.units if u.unit_role == "intertitre")
 
     # Single transaction: document record + units
     try:
@@ -123,7 +139,6 @@ def import_docx_paragraphs(
         )
         doc_id = cur.lastrowid
         log.info("Created document doc_id=%d title=%r", doc_id, doc_title)
-        has_headings = any(level is not None for _, level in para_data)
         if has_headings:
             conn.execute(
                 """
@@ -143,7 +158,6 @@ def import_docx_paragraphs(
         conn.rollback()
         raise
 
-    n_headings = sum(1 for _, level in para_data if level is not None)
     report = ImportReport(
         doc_id=doc_id,
         units_total=len(units_parsed),

--- a/src/multicorpus_engine/importers/odt_numbered_lines.py
+++ b/src/multicorpus_engine/importers/odt_numbered_lines.py
@@ -13,10 +13,10 @@ from ..unicode_policy import count_sep, normalize
 from .docx_numbered_lines import (
     ImportReport,
     _analyze_external_ids,
-    _compute_file_hash,
 )
 from .import_guard import assert_not_duplicate_import
 from .odt_common import read_odt_paragraph_rich_lines
+from .parsed import file_sha256
 
 _NUMBERED_RE = re.compile(r"^\[\s*(\d+)\s*\]\s*(.+)$", re.DOTALL)
 
@@ -46,7 +46,7 @@ def import_odt_numbered_lines(
     log = run_logger or logger
     log.info("Starting import of %s (mode=odt_numbered_lines)", path)
 
-    source_hash = _compute_file_hash(path)
+    source_hash = file_sha256(path)
     assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
     doc_title = title or path.stem
     utcnow = __import__("datetime").datetime.now(

--- a/src/multicorpus_engine/importers/odt_numbered_lines.py
+++ b/src/multicorpus_engine/importers/odt_numbered_lines.py
@@ -16,11 +16,59 @@ from .docx_numbered_lines import (
 )
 from .import_guard import assert_not_duplicate_import
 from .odt_common import read_odt_paragraph_rich_lines
-from .parsed import file_sha256
+from .parsed import ParsedDoc, ParsedUnit, file_sha256
 
 _NUMBERED_RE = re.compile(r"^\[\s*(\d+)\s*\]\s*(.+)$", re.DOTALL)
 
 logger = logging.getLogger(__name__)
+
+
+def parse_odt_numbered_lines(
+    path: str | Path,
+    run_logger: Optional[logging.Logger] = None,
+) -> ParsedDoc:
+    """Parse an ODT (numbered-lines ``[n]`` convention) into units WITHOUT touching
+    the DB. Shared by ``import_odt_numbered_lines`` (write path) and the sidecar
+    ``/import/preview`` so the parsing lives in exactly one place (A-02). Raises
+    ``FileNotFoundError`` / ``ValueError`` like the importer did.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"ODT file not found: {path}")
+
+    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
+    if path.stat().st_size > _MAX_FILE_BYTES:
+        raise ValueError(f"ODT file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
+
+    source_hash = file_sha256(path)
+
+    units: list[ParsedUnit] = []
+    n = 0
+    for rich, _heading_level in read_odt_paragraph_rich_lines(path):
+        plain = normalize(rich).strip()
+        if not plain:
+            continue
+        n += 1
+        # Match on plain text so a styled [n] prefix is still detected.
+        m = _NUMBERED_RE.match(plain)
+        if m:
+            ext_id = int(m.group(1))
+            # Strip the plain prefix from rich to preserve styling in the content.
+            prefix_len = m.start(2)
+            text_raw = rich[prefix_len:] if len(rich) >= prefix_len else m.group(2)
+            text_norm = normalize(text_raw)
+            sep_count = count_sep(text_raw)
+            meta = json.dumps({"sep_count": sep_count}) if sep_count > 0 else None
+            units.append(ParsedUnit(
+                n=n, unit_type="line", text_raw=text_raw, text_norm=text_norm,
+                external_id=ext_id, meta_json=meta,
+            ))
+        else:
+            units.append(ParsedUnit(
+                n=n, unit_type="structure", text_raw=rich, text_norm=normalize(rich),
+            ))
+
+    return ParsedDoc(units=units, doc_meta={}, source_hash=source_hash)
 
 
 def import_odt_numbered_lines(
@@ -36,78 +84,42 @@ def import_odt_numbered_lines(
 ) -> ImportReport:
     """Import an ODT file using the numbered-lines ``[n]`` convention (see ADR-001)."""
     path = Path(path)
-    if not path.exists():
-        raise FileNotFoundError(f"ODT file not found: {path}")
-
-    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
-    if path.stat().st_size > _MAX_FILE_BYTES:
-        raise ValueError(f"ODT file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
-
     log = run_logger or logger
     log.info("Starting import of %s (mode=odt_numbered_lines)", path)
 
-    source_hash = file_sha256(path)
-    assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
+    parsed = parse_odt_numbered_lines(path, run_logger=run_logger)
+    assert_not_duplicate_import(conn, path, parsed.source_hash, check_filename=check_filename)
     doc_title = title or path.stem
     utcnow = __import__("datetime").datetime.now(
         __import__("datetime").timezone.utc
     ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    external_ids: list[int] = []
-    units_to_insert: list[tuple] = []
+    external_ids: list[int] = [
+        u.external_id for u in parsed.units
+        if u.unit_type == "line" and u.external_id is not None
+    ]
 
     try:
-        paragraphs = [rich for rich, _ in read_odt_paragraph_rich_lines(path)]
-
         cur = conn.execute(
             """
             INSERT INTO documents
                 (title, language, doc_role, resource_type, meta_json, source_path, source_hash, created_at)
             VALUES (?, ?, ?, ?, NULL, ?, ?, ?)
             """,
-            (doc_title, language, doc_role, resource_type, str(path), source_hash, utcnow),
+            (doc_title, language, doc_role, resource_type, str(path), parsed.source_hash, utcnow),
         )
         doc_id = cur.lastrowid
         log.info("Created document doc_id=%d title=%r", doc_id, doc_title)
-
-        n = 0
-        for rich in paragraphs:
-            plain = normalize(rich).strip()
-            if not plain:
-                continue
-
-            n += 1
-            # Match on plain text so a styled [n] prefix is still detected
-            m = _NUMBERED_RE.match(plain)
-            if m:
-                ext_id = int(m.group(1))
-                # Strip the plain prefix from rich to preserve styling in the content
-                prefix_len = m.start(2)
-                text_raw = rich[prefix_len:] if len(rich) >= prefix_len else m.group(2)
-                text_norm = normalize(text_raw)
-                sep_count = count_sep(text_raw)
-                meta = json.dumps({"sep_count": sep_count}) if sep_count > 0 else None
-                unit_type = "line"
-                external_ids.append(ext_id)
-                units_to_insert.append(
-                    (doc_id, unit_type, n, ext_id, text_raw, text_norm, meta)
-                )
-                log.debug("Para n=%d ext_id=%d type=line", n, ext_id)
-            else:
-                text_raw = rich
-                text_norm = normalize(text_raw)
-                unit_type = "structure"
-                units_to_insert.append(
-                    (doc_id, unit_type, n, None, text_raw, text_norm, None)
-                )
-                log.debug("Para n=%d type=structure", n)
 
         conn.executemany(
             """
             INSERT INTO units (doc_id, unit_type, n, external_id, text_raw, text_norm, meta_json)
             VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            units_to_insert,
+            [
+                (doc_id, u.unit_type, u.n, u.external_id, u.text_raw, u.text_norm, u.meta_json)
+                for u in parsed.units
+            ],
         )
         conn.commit()
     except Exception:
@@ -118,9 +130,9 @@ def import_odt_numbered_lines(
 
     report = ImportReport(
         doc_id=doc_id,
-        units_total=len(units_to_insert),
+        units_total=len(parsed.units),
         units_line=len(external_ids),
-        units_structure=len(units_to_insert) - len(external_ids),
+        units_structure=len(parsed.units) - len(external_ids),
         duplicates=duplicates,
         holes=holes,
         non_monotonic=non_monotonic,

--- a/src/multicorpus_engine/importers/odt_paragraphs.py
+++ b/src/multicorpus_engine/importers/odt_paragraphs.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from ..unicode_policy import count_sep, normalize
 from .docx_numbered_lines import ImportReport
-from .docx_paragraphs import _compute_file_hash
+from .parsed import file_sha256
 from .import_guard import assert_not_duplicate_import
 from .odt_common import read_odt_paragraph_rich_lines
 
@@ -40,7 +40,7 @@ def import_odt_paragraphs(
     log = run_logger or logger
     log.info("Starting import of %s (mode=odt_paragraphs)", path)
 
-    source_hash = _compute_file_hash(path)
+    source_hash = file_sha256(path)
     assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
     doc_title = title or path.stem
     utcnow = __import__("datetime").datetime.now(

--- a/src/multicorpus_engine/importers/odt_paragraphs.py
+++ b/src/multicorpus_engine/importers/odt_paragraphs.py
@@ -10,11 +10,51 @@ from typing import Optional
 
 from ..unicode_policy import count_sep, normalize
 from .docx_numbered_lines import ImportReport
-from .parsed import file_sha256
 from .import_guard import assert_not_duplicate_import
 from .odt_common import read_odt_paragraph_rich_lines
+from .parsed import ParsedDoc, ParsedUnit, file_sha256
 
 logger = logging.getLogger(__name__)
+
+
+def parse_odt_paragraphs(
+    path: str | Path,
+    run_logger: Optional[logging.Logger] = None,
+) -> ParsedDoc:
+    """Parse an ODT into one line unit per non-empty paragraph, WITHOUT touching
+    the DB. Shared by ``import_odt_paragraphs`` and ``/import/preview`` (A-02).
+    Sequential position (1-based) is both n and external_id; ``text:h`` headings
+    get unit_role="intertitre" + meta heading_level.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"ODT file not found: {path}")
+
+    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
+    if path.stat().st_size > _MAX_FILE_BYTES:
+        raise ValueError(f"ODT file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
+
+    source_hash = file_sha256(path)
+
+    units: list[ParsedUnit] = []
+    n = 0
+    for text_raw, heading_level in read_odt_paragraph_rich_lines(path):
+        n += 1
+        text_norm = normalize(text_raw)
+        sep_count = count_sep(text_raw)
+        meta_dict: dict = {}
+        if sep_count > 0:
+            meta_dict["sep_count"] = sep_count
+        if heading_level is not None:
+            meta_dict["heading_level"] = heading_level
+        meta = json.dumps(meta_dict) if meta_dict else None
+        unit_role = "intertitre" if heading_level is not None else None
+        units.append(ParsedUnit(
+            n=n, unit_type="line", text_raw=text_raw, text_norm=text_norm,
+            external_id=n, meta_json=meta, unit_role=unit_role,
+        ))
+
+    return ParsedDoc(units=units, doc_meta={}, source_hash=source_hash)
 
 
 def import_odt_paragraphs(
@@ -30,54 +70,31 @@ def import_odt_paragraphs(
 ) -> ImportReport:
     """Import an ODT file — every non-empty ``text:p`` / ``text:h`` becomes a line unit."""
     path = Path(path)
-    if not path.exists():
-        raise FileNotFoundError(f"ODT file not found: {path}")
-
-    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
-    if path.stat().st_size > _MAX_FILE_BYTES:
-        raise ValueError(f"ODT file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
-
     log = run_logger or logger
     log.info("Starting import of %s (mode=odt_paragraphs)", path)
 
-    source_hash = file_sha256(path)
-    assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
+    parsed = parse_odt_paragraphs(path, run_logger=run_logger)
+    assert_not_duplicate_import(conn, path, parsed.source_hash, check_filename=check_filename)
     doc_title = title or path.stem
     utcnow = __import__("datetime").datetime.now(
         __import__("datetime").timezone.utc
     ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    try:
-        para_texts = read_odt_paragraph_rich_lines(path)
+    has_headings = any(u.unit_role == "intertitre" for u in parsed.units)
+    n_headings = sum(1 for u in parsed.units if u.unit_role == "intertitre")
 
+    try:
         cur = conn.execute(
             """
             INSERT INTO documents
                 (title, language, doc_role, resource_type, meta_json, source_path, source_hash, created_at)
             VALUES (?, ?, ?, ?, NULL, ?, ?, ?)
             """,
-            (doc_title, language, doc_role, resource_type, str(path), source_hash, utcnow),
+            (doc_title, language, doc_role, resource_type, str(path), parsed.source_hash, utcnow),
         )
         doc_id = cur.lastrowid
         log.info("Created document doc_id=%d title=%r", doc_id, doc_title)
 
-        units_to_insert: list[tuple] = []
-        n = 0
-
-        for text_raw, heading_level in para_texts:
-            n += 1
-            text_norm = normalize(text_raw)
-            sep_count = count_sep(text_raw)
-            meta_dict: dict = {}
-            if sep_count > 0:
-                meta_dict["sep_count"] = sep_count
-            if heading_level is not None:
-                meta_dict["heading_level"] = heading_level
-            meta = json.dumps(meta_dict) if meta_dict else None
-            unit_role = "intertitre" if heading_level is not None else None
-            units_to_insert.append((doc_id, "line", n, n, text_raw, text_norm, meta, unit_role))
-
-        has_headings = any(level is not None for _, level in para_texts)
         if has_headings:
             conn.execute(
                 """
@@ -90,18 +107,20 @@ def import_odt_paragraphs(
             INSERT INTO units (doc_id, unit_type, n, external_id, text_raw, text_norm, meta_json, unit_role)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            units_to_insert,
+            [
+                (doc_id, u.unit_type, u.n, u.external_id, u.text_raw, u.text_norm, u.meta_json, u.unit_role)
+                for u in parsed.units
+            ],
         )
         conn.commit()
     except Exception:
         conn.rollback()
         raise
 
-    n_headings = sum(1 for _, level in para_texts if level is not None)
     report = ImportReport(
         doc_id=doc_id,
-        units_total=len(units_to_insert),
-        units_line=len(units_to_insert),
+        units_total=len(parsed.units),
+        units_line=len(parsed.units),
         units_structure=0,
         duplicates=[],
         holes=[],

--- a/src/multicorpus_engine/importers/parsed.py
+++ b/src/multicorpus_engine/importers/parsed.py
@@ -1,0 +1,50 @@
+"""Shared parse-layer types (audit P0-1 / A-02).
+
+Each importer exposes a ``parse_<mode>(path) -> ParsedDoc`` that turns a file into
+units WITHOUT touching the DB. Two consumers share that single parsing logic:
+  - the importer's write path (``import_<mode>``) inserts the units;
+  - the sidecar ``/import/preview`` projects them via :func:`to_preview`.
+This removes the duplicate parsing the preview used to reimplement (A-02).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class ParsedUnit:
+    """One parsed unit, before it is assigned a doc_id and written."""
+
+    n: int
+    unit_type: str  # "line" | "structure"
+    text_raw: str
+    text_norm: str
+    external_id: Optional[int] = None
+    meta_json: Optional[str] = None
+    unit_role: Optional[str] = None
+
+
+@dataclass
+class ParsedDoc:
+    """Result of parsing a source file: its units + document-level metadata."""
+
+    units: list[ParsedUnit] = field(default_factory=list)
+    doc_meta: dict[str, Any] = field(default_factory=dict)  # -> document.meta_json
+    source_hash: str = ""
+
+
+def to_preview(units: list[ParsedUnit], limit: int) -> tuple[list[dict], int]:
+    """Project parsed units to the /import/preview shape: (units[:limit], total)."""
+    total = len(units)
+    preview = [
+        {
+            "n": u.n,
+            "external_id": u.external_id,
+            "unit_type": u.unit_type,
+            "text_raw": u.text_raw,
+        }
+        for u in units[:limit]
+    ]
+    return preview, total

--- a/src/multicorpus_engine/importers/parsed.py
+++ b/src/multicorpus_engine/importers/parsed.py
@@ -9,8 +9,20 @@ This removes the duplicate parsing the preview used to reimplement (A-02).
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional
+
+
+def file_sha256(path: str | Path) -> str:
+    """Streaming SHA-256 of a file (audit Q-03: one definition, was duplicated in
+    5 importers as ``_compute_file_hash``)."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
 
 
 @dataclass
@@ -33,6 +45,7 @@ class ParsedDoc:
     units: list[ParsedUnit] = field(default_factory=list)
     doc_meta: dict[str, Any] = field(default_factory=dict)  # -> document.meta_json
     source_hash: str = ""
+    stats: dict[str, Any] = field(default_factory=dict)  # parse-derived diagnostics (e.g. docx tables)
 
 
 def to_preview(units: list[ParsedUnit], limit: int) -> tuple[list[dict], int]:

--- a/src/multicorpus_engine/importers/tei_importer.py
+++ b/src/multicorpus_engine/importers/tei_importer.py
@@ -15,7 +15,6 @@ Design decisions (ADR-014):
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import re
 import sqlite3
@@ -28,6 +27,7 @@ from ..unicode_policy import count_sep, normalize
 from .import_guard import assert_not_duplicate_import
 import json
 from .docx_numbered_lines import ImportReport, _analyze_external_ids
+from .parsed import file_sha256
 from ..utils.tei_validate import validate_tei_tree, summarize_tei_validation
 
 _TEI_NS = "http://www.tei-c.org/ns/1.0"
@@ -38,14 +38,6 @@ _ATTR_LANG = f"{{{_XML_NS}}}lang"
 _ATTR_ID = f"{{{_XML_NS}}}id"
 
 logger = logging.getLogger(__name__)
-
-
-def _compute_file_hash(path: Path) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(65536), b""):
-            h.update(chunk)
-    return h.hexdigest()
 
 
 def _xmlid_to_int(xmlid: str) -> Optional[int]:
@@ -162,7 +154,7 @@ def import_tei(
     log = run_logger or logger
     log.info("Starting import of %s (mode=tei, unit=%s)", path, unit_element)
 
-    source_hash = _compute_file_hash(path)
+    source_hash = file_sha256(path)
     assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
 
     try:

--- a/src/multicorpus_engine/importers/tei_importer.py
+++ b/src/multicorpus_engine/importers/tei_importer.py
@@ -27,7 +27,7 @@ from ..unicode_policy import count_sep, normalize
 from .import_guard import assert_not_duplicate_import
 import json
 from .docx_numbered_lines import ImportReport, _analyze_external_ids
-from .parsed import file_sha256
+from .parsed import ParsedDoc, ParsedUnit, file_sha256
 from ..utils.tei_validate import validate_tei_tree, summarize_tei_validation
 
 _TEI_NS = "http://www.tei-c.org/ns/1.0"
@@ -112,6 +112,76 @@ def _get_lang(root: ET.Element) -> Optional[str]:
     return lang or None
 
 
+def parse_tei(
+    path: str | Path,
+    unit_element: str = "p",
+    run_logger: Optional[logging.Logger] = None,
+) -> ParsedDoc:
+    """Parse a TEI XML file (extract <p>/<s> as line units) WITHOUT touching the DB.
+
+    Shared by ``import_tei`` (write path) and the sidecar ``/import/preview`` so the
+    element walk, the xml:id→external_id mapping (numeric suffix, fallback to the
+    sequential position) and TEI validation live in exactly one place (A-02).
+    Header-derived title/lang and validation issues are returned in
+    ``ParsedDoc.stats`` for the writer to apply/report. Raises ``ValueError`` /
+    ``FileNotFoundError`` like the importer did.
+    """
+    if unit_element not in ("p", "s"):
+        raise ValueError(f"unit_element must be 'p' or 's', got {unit_element!r}")
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"TEI file not found: {path}")
+
+    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
+    if path.stat().st_size > _MAX_FILE_BYTES:
+        raise ValueError(f"TEI file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
+
+    source_hash = file_sha256(path)
+
+    try:
+        tree = DefET.parse(str(path))
+    except ET.ParseError as exc:
+        raise ValueError(f"TEI file is not valid XML: {exc}") from exc
+
+    root = tree.getroot()
+    tei_validation_issues = validate_tei_tree(root, source_path=str(path))
+
+    elements = _iter_body_elements(root, unit_element)
+    units: list[ParsedUnit] = []
+    n = 0
+    for el in elements:
+        # Get all text content (including tail text of children)
+        raw_text = "".join(el.itertext()).strip()
+        if not raw_text:
+            continue  # skip empty elements
+        n += 1
+        text_raw = raw_text
+        text_norm = normalize(text_raw)
+        sep_count = count_sep(text_raw)
+        meta = json.dumps({"sep_count": sep_count}) if sep_count > 0 else None
+        # external_id from xml:id numeric suffix, fallback to sequential position.
+        xmlid = el.get(_ATTR_ID) or el.get("id")
+        ext_id: Optional[int] = _xmlid_to_int(xmlid) if xmlid else None
+        if ext_id is None:
+            ext_id = n
+        units.append(ParsedUnit(
+            n=n, unit_type="line", text_raw=text_raw, text_norm=text_norm,
+            external_id=ext_id, meta_json=meta,
+        ))
+
+    return ParsedDoc(
+        units=units,
+        doc_meta={"tei_unit": unit_element},
+        source_hash=source_hash,
+        stats={
+            "header_title": _get_title(root),
+            "header_lang": _get_lang(root),
+            "validation_issues": tei_validation_issues,
+        },
+    )
+
+
 def import_tei(
     conn: sqlite3.Connection,
     path: str | Path,
@@ -140,69 +210,29 @@ def import_tei(
     Returns:
         ImportReport with diagnostics.
     """
-    if unit_element not in ("p", "s"):
-        raise ValueError(f"unit_element must be 'p' or 's', got {unit_element!r}")
-
     path = Path(path)
-    if not path.exists():
-        raise FileNotFoundError(f"TEI file not found: {path}")
-
-    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
-    if path.stat().st_size > _MAX_FILE_BYTES:
-        raise ValueError(f"TEI file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
-
     log = run_logger or logger
     log.info("Starting import of %s (mode=tei, unit=%s)", path, unit_element)
 
-    source_hash = file_sha256(path)
-    assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
+    parsed = parse_tei(path, unit_element=unit_element, run_logger=run_logger)
+    assert_not_duplicate_import(conn, path, parsed.source_hash, check_filename=check_filename)
+    source_hash = parsed.source_hash
+    tei_validation_issues = parsed.stats["validation_issues"]
 
-    try:
-        tree = DefET.parse(str(path))
-    except ET.ParseError as exc:
-        raise ValueError(f"TEI file is not valid XML: {exc}") from exc
-
-    root = tree.getroot()
-    tei_validation_issues = validate_tei_tree(root, source_path=str(path))
-
-    # Resolve title and language from TEI header if not supplied
-    tei_title = title or _get_title(root) or path.stem
-    tei_lang = language or _get_lang(root) or "und"  # und = undetermined
+    # Resolve title and language: explicit arg > TEI header > fallback.
+    tei_title = title or parsed.stats["header_title"] or path.stem
+    tei_lang = language or parsed.stats["header_lang"] or "und"  # und = undetermined
 
     utcnow = __import__("datetime").datetime.now(
         __import__("datetime").timezone.utc
     ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    # Extract elements (in-memory XML, no I/O) — build units_parsed before opening transaction
-    elements = _iter_body_elements(root, unit_element)
-    external_ids: list[int] = []
-    # (unit_type, n, ext_id, text_raw, text_norm, meta) — doc_id added after INSERT
-    units_parsed: list[tuple] = []
-    n = 0
-
-    for el in elements:
-        # Get all text content (including tail text of children)
-        raw_text = "".join(el.itertext()).strip()
-        if not raw_text:
-            continue  # skip empty elements
-
-        n += 1
-        text_raw = raw_text
-        text_norm = normalize(text_raw)
-        sep_count = count_sep(text_raw)
-        meta = json.dumps({"sep_count": sep_count}) if sep_count > 0 else None
-
-        # external_id from xml:id numeric suffix
-        xmlid = el.get(_ATTR_ID) or el.get("id")
-        ext_id: Optional[int] = None
-        if xmlid:
-            ext_id = _xmlid_to_int(xmlid)
-        if ext_id is None:
-            ext_id = n  # fallback to sequential position
-
-        external_ids.append(ext_id)
-        units_parsed.append(("line", n, ext_id, text_raw, text_norm, meta))
-        log.debug("TEI %s n=%d ext_id=%d", unit_element, n, ext_id)
+    # Project parsed units onto DB-insert tuples (doc_id added after INSERT).
+    external_ids: list[int] = [u.external_id for u in parsed.units]
+    units_parsed: list[tuple] = [
+        (u.unit_type, u.n, u.external_id, u.text_raw, u.text_norm, u.meta_json)
+        for u in parsed.units
+    ]
 
     # Single transaction: document record + units
     try:

--- a/src/multicorpus_engine/importers/txt.py
+++ b/src/multicorpus_engine/importers/txt.py
@@ -25,6 +25,7 @@ from typing import Optional
 from ..unicode_policy import count_sep, normalize
 from .import_guard import assert_not_duplicate_import
 from .docx_numbered_lines import ImportReport, _analyze_external_ids
+from .parsed import ParsedDoc, ParsedUnit
 
 _NUMBERED_RE = re.compile(r"^\[\s*(\d+)\s*\]\s*(.+)$")
 
@@ -69,6 +70,64 @@ def _detect_encoding(data: bytes) -> tuple[str, str]:
         return ("latin-1", "latin-1-fallback")
 
 
+def parse_txt_numbered_lines(
+    path: str | Path,
+    run_logger: Optional[logging.Logger] = None,
+) -> ParsedDoc:
+    """Parse a numbered-lines TXT file into units WITHOUT touching the DB.
+
+    Shared by ``import_txt_numbered_lines`` (write path) and the sidecar
+    ``/import/preview`` so the parsing logic lives in exactly one place (A-02).
+    Raises ``FileNotFoundError`` / ``ValueError`` like the importer did.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"TXT file not found: {path}")
+
+    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
+    if path.stat().st_size > _MAX_FILE_BYTES:
+        raise ValueError(f"TXT file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
+    raw_bytes = path.read_bytes()
+    source_hash = hashlib.sha256(raw_bytes).hexdigest()
+    encoding, enc_method = _detect_encoding(raw_bytes)
+
+    # Encoding fallback: only the run_logger (CLI run log) — never the module
+    # logger (would hit stderr in the sidecar).
+    if enc_method in ("cp1252-fallback", "latin-1-fallback") and run_logger is not None:
+        run_logger.warning("Encoding detection fell back to %s for %s", encoding, path.name)
+
+    text = raw_bytes.decode(encoding, errors="replace")
+
+    units: list[ParsedUnit] = []
+    n = 0
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue  # skip blank lines
+        n += 1
+        m = _NUMBERED_RE.match(line)
+        if m:
+            ext_id = int(m.group(1))
+            text_raw = m.group(2)
+            sep_count = count_sep(text_raw)
+            meta = json.dumps({"sep_count": sep_count}) if sep_count > 0 else None
+            units.append(ParsedUnit(
+                n=n, unit_type="line", text_raw=text_raw, text_norm=normalize(text_raw),
+                external_id=ext_id, meta_json=meta,
+            ))
+        else:
+            units.append(ParsedUnit(
+                n=n, unit_type="structure", text_raw=line, text_norm=normalize(line),
+                unit_role="intertitre",
+            ))
+
+    return ParsedDoc(
+        units=units,
+        doc_meta={"encoding": encoding, "enc_method": enc_method},
+        source_hash=source_hash,
+    )
+
+
 def import_txt_numbered_lines(
     conn: sqlite3.Connection,
     path: str | Path,
@@ -89,29 +148,13 @@ def import_txt_numbered_lines(
     Returns an ImportReport with diagnostics (same as docx_numbered_lines).
     """
     path = Path(path)
-    if not path.exists():
-        raise FileNotFoundError(f"TXT file not found: {path}")
-
     log = run_logger or logger
     log.info("Starting import of %s (mode=txt_numbered_lines)", path)
 
-    _MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB
-    if path.stat().st_size > _MAX_FILE_BYTES:
-        raise ValueError(f"TXT file too large (max {_MAX_FILE_BYTES // (1024 * 1024)} MiB)")
-    raw_bytes = path.read_bytes()
-    source_hash = hashlib.sha256(raw_bytes).hexdigest()
-    assert_not_duplicate_import(conn, path, source_hash, check_filename=check_filename)
-    encoding, enc_method = _detect_encoding(raw_bytes)
-
-    # Encoding fallback: do not use module logger (would go to stderr in sidecar).
-    # Only run_logger (CLI run log file) and structured stats_json.
-    if enc_method in ("cp1252-fallback", "latin-1-fallback"):
-        if run_logger is not None:
-            run_logger.warning(
-                "Encoding detection fell back to %s for %s", encoding, path.name
-            )
-
-    text = raw_bytes.decode(encoding, errors="replace")
+    parsed = parse_txt_numbered_lines(path, run_logger=run_logger)
+    assert_not_duplicate_import(conn, path, parsed.source_hash, check_filename=check_filename)
+    encoding = parsed.doc_meta["encoding"]
+    enc_method = parsed.doc_meta["enc_method"]
     log.info("Decoded %s as %s (method=%s)", path.name, encoding, enc_method)
 
     doc_title = title or path.stem
@@ -128,49 +171,24 @@ def import_txt_numbered_lines(
         """,
         (
             doc_title, language, doc_role, resource_type,
-            json.dumps({"encoding": encoding, "enc_method": enc_method}),
-            str(path), source_hash, utcnow,
+            json.dumps(parsed.doc_meta),
+            str(path), parsed.source_hash, utcnow,
         ),
     )
     doc_id = cur.lastrowid
 
     log.info("Created document doc_id=%d title=%r", doc_id, doc_title)
 
-    # Parse lines
-    lines = text.splitlines()
-    external_ids: list[int] = []
-    units_to_insert: list[tuple] = []
-    has_structure = False
-    n = 0
-
-    for raw_line in lines:
-        line = raw_line.strip()
-        if not line:
-            continue  # skip blank lines
-
-        n += 1
-        m = _NUMBERED_RE.match(line)
-        if m:
-            ext_id = int(m.group(1))
-            text_raw = m.group(2)
-            text_norm = normalize(text_raw)
-            sep_count = count_sep(text_raw)
-            meta = json.dumps({"sep_count": sep_count}) if sep_count > 0 else None
-            unit_type = "line"
-            external_ids.append(ext_id)
-            units_to_insert.append(
-                (doc_id, unit_type, n, ext_id, text_raw, text_norm, meta, None)
-            )
-            log.debug("Line n=%d ext_id=%d type=line", n, ext_id)
-        else:
-            text_raw = line
-            text_norm = normalize(text_raw)
-            unit_type = "structure"
-            has_structure = True
-            units_to_insert.append(
-                (doc_id, unit_type, n, None, text_raw, text_norm, None, "intertitre")
-            )
-            log.debug("Line n=%d type=structure", n)
+    # Project parsed units onto DB rows (doc_id assigned now).
+    external_ids: list[int] = [
+        u.external_id for u in parsed.units
+        if u.unit_type == "line" and u.external_id is not None
+    ]
+    has_structure = any(u.unit_type == "structure" for u in parsed.units)
+    units_to_insert: list[tuple] = [
+        (doc_id, u.unit_type, u.n, u.external_id, u.text_raw, u.text_norm, u.meta_json, u.unit_role)
+        for u in parsed.units
+    ]
 
     try:
         # Auto-create intertitre convention if structure lines are present

--- a/src/multicorpus_engine/importers/txt.py
+++ b/src/multicorpus_engine/importers/txt.py
@@ -32,14 +32,6 @@ _NUMBERED_RE = re.compile(r"^\[\s*(\d+)\s*\]\s*(.+)$")
 logger = logging.getLogger(__name__)
 
 
-def _compute_file_hash(path: Path) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(65536), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
 def _detect_encoding(data: bytes) -> tuple[str, str]:
     """Detect text encoding from BOM or charset-normalizer.
 

--- a/src/multicorpus_engine/sidecar.py
+++ b/src/multicorpus_engine/sidecar.py
@@ -2115,91 +2115,12 @@ class _CorpusHandler(BaseHTTPRequestHandler):
 
         if mode == "conllu":
             try:
-                raw_bytes = fpath.read_bytes()
-                try:
-                    text = raw_bytes.decode("utf-8-sig")
-                except UnicodeDecodeError:
-                    text = raw_bytes.decode("latin-1")
-
-                sentences_total = 0
-                tokens_total = 0
-                skipped_ranges = 0
-                skipped_empty_nodes = 0
-                malformed_lines = 0
-                sample_rows: list[dict] = []
-
-                # First pass : token + skip counters only. Sentence counting
-                # is done in the dedicated "Recount sentences" pass below.
-                for raw_line in text.splitlines():
-                    line = raw_line.strip()
-                    if not line:
-                        continue
-                    if line.startswith("#"):
-                        continue
-                    cols = raw_line.split("\t")
-                    if len(cols) != 10:
-                        malformed_lines += 1
-                        continue
-                    token_id = cols[0].strip()
-                    if "-" in token_id:
-                        skipped_ranges += 1
-                        continue
-                    if "." in token_id:
-                        skipped_empty_nodes += 1
-                        continue
-                    tokens_total += 1
-
-                # Recount sentences (blank-line delimited blocks with tokens)
-                sentences_total = 0
-                in_sentence = False
-                has_tokens = False
-                sample_sent = 0
-                sample_rows = []
-
-                for raw_line in text.splitlines():
-                    line = raw_line.strip()
-                    if not line:
-                        if has_tokens:
-                            sentences_total += 1
-                        in_sentence = False
-                        has_tokens = False
-                        continue
-                    if line.startswith("#"):
-                        if not in_sentence:
-                            in_sentence = True
-                            sample_sent += 1
-                        continue
-                    cols = raw_line.split("\t")
-                    if len(cols) != 10:
-                        continue
-                    token_id = cols[0].strip()
-                    if "-" in token_id or "." in token_id:
-                        continue
-                    has_tokens = True
-                    if len(sample_rows) < limit:
-                        lemma = cols[2].strip()
-                        upos = cols[3].strip()
-                        sample_rows.append({
-                            "sent": sample_sent,
-                            "id": token_id,
-                            "form": cols[1].strip(),
-                            "lemma": "\u2014" if lemma == "_" else lemma,
-                            "upos": "\u2014" if upos == "_" else upos,
-                        })
-
-                if has_tokens:
-                    sentences_total += 1
-
+                # A-02: lenient preview scan lives in the importer module, next to
+                # the strict parser - no reimplementation here.
+                from multicorpus_engine.importers.conllu import preview_conllu
                 self._send_json(success_payload({
                     "mode": mode,
-                    "conllu_stats": {
-                        "sentences": sentences_total,
-                        "tokens": tokens_total,
-                        "skipped_ranges": skipped_ranges,
-                        "skipped_empty_nodes": skipped_empty_nodes,
-                        "malformed_lines": malformed_lines,
-                        "sample_rows": sample_rows,
-                    },
+                    "conllu_stats": preview_conllu(fpath, limit),
                 }))
             except Exception as exc:
                 logger.exception("Preview CoNLL-U error: %s", exc)
@@ -2226,96 +2147,33 @@ class _CorpusHandler(BaseHTTPRequestHandler):
         Each unit dict: { n, external_id, unit_type, text_raw }
         Supported modes: txt_numbered_lines, docx_numbered_lines, docx_paragraphs,
                          odt_numbered_lines, odt_paragraphs, tei.
+
+        A-02: every mode goes through the importer's own ``parse_<mode>`` so the
+        preview shows EXACTLY what an import would write — no parsing is
+        reimplemented here.
         """
-        import re as _re
-        from multicorpus_engine.unicode_policy import normalize as _norm
-
-        _NUMBERED_RE = _re.compile(r"^\[\s*(\d+)\s*\]\s*(.+)$", _re.DOTALL)
-
-        units_all: list[dict] = []
+        from multicorpus_engine.importers import (
+            docx_numbered_lines, docx_paragraphs,
+            odt_numbered_lines, odt_paragraphs, tei_importer, txt,
+        )
+        from multicorpus_engine.importers.parsed import to_preview
 
         if mode in ("txt_numbered_lines", "txt"):
-            from multicorpus_engine.importers.txt import _detect_encoding  # type: ignore[attr-defined]
-            raw_bytes = fpath.read_bytes()
-            encoding, _ = _detect_encoding(raw_bytes)
-            text = raw_bytes.decode(encoding, errors="replace")
-            n = 0
-            for raw_line in text.splitlines():
-                line = raw_line.strip()
-                if not line:
-                    continue
-                n += 1
-                m = _NUMBERED_RE.match(line)
-                if m:
-                    units_all.append({"n": n, "external_id": int(m.group(1)), "unit_type": "line", "text_raw": m.group(2)})
-                else:
-                    units_all.append({"n": n, "external_id": None, "unit_type": "structure", "text_raw": line})
-
-        elif mode in ("docx_numbered_lines", "docx_paragraphs", "docx"):
-            import docx as _docx  # type: ignore[import]
-            from multicorpus_engine.importers.rich_text import para_to_rich_text as _p2r  # type: ignore[attr-defined]
-            document = _docx.Document(str(fpath))
-            n = 0
-            for para in document.paragraphs:
-                rich = _p2r(para)
-                plain = _norm(rich).strip()
-                if not plain:
-                    continue
-                n += 1
-                if mode != "docx_paragraphs":
-                    m = _NUMBERED_RE.match(plain)
-                    if m:
-                        # Strip the [n] prefix from rich text using the plain-text match length
-                        prefix = m.group(0)[: m.start(2)]  # e.g. "[12] "
-                        text_raw = rich[len(prefix):].strip() if rich.startswith(prefix) else m.group(2)
-                        units_all.append({"n": n, "external_id": int(m.group(1)), "unit_type": "line", "text_raw": text_raw})
-                        continue
-                units_all.append({"n": n, "external_id": n, "unit_type": "line", "text_raw": rich})
-
-        elif mode in ("odt_numbered_lines", "odt_paragraphs", "odt"):
-            from multicorpus_engine.importers.odt_common import read_odt_paragraph_rich_lines as _odt  # type: ignore[attr-defined]
-            paragraphs = _odt(fpath)
-            n = 0
-            for rich in paragraphs:
-                plain = _norm(rich).strip()
-                if not plain:
-                    continue
-                n += 1
-                if mode != "odt_paragraphs":
-                    m = _NUMBERED_RE.match(plain)
-                    if m:
-                        prefix = m.group(0)[: m.start(2)]
-                        text_raw = rich[len(prefix):].strip() if rich.startswith(prefix) else m.group(2)
-                        units_all.append({"n": n, "external_id": int(m.group(1)), "unit_type": "line", "text_raw": text_raw})
-                        continue
-                units_all.append({"n": n, "external_id": n, "unit_type": "line", "text_raw": rich})
-
-        elif mode in ("tei",):
-            import defusedxml.ElementTree as _DefET
-            from multicorpus_engine.importers.tei_importer import _iter_body_elements, _xmlid_to_int  # type: ignore[attr-defined]
-            _ATTR_ID = "{http://www.w3.org/XML/1998/namespace}id"
-            raw_bytes = fpath.read_bytes()
-            try:
-                text_content = raw_bytes.decode("utf-8-sig")
-            except UnicodeDecodeError:
-                text_content = raw_bytes.decode("latin-1")
-            root = _DefET.fromstring(text_content)
-            elements = _iter_body_elements(root, "p")
-            n = 0
-            for el in elements:
-                text_raw = "".join(el.itertext()).strip()
-                if not text_raw:
-                    continue
-                n += 1
-                xmlid = el.get(_ATTR_ID) or el.get("id")
-                ext_id = _xmlid_to_int(xmlid) if xmlid else n
-                units_all.append({"n": n, "external_id": ext_id, "unit_type": "line", "text_raw": text_raw})
-
+            parsed = txt.parse_txt_numbered_lines(fpath)
+        elif mode in ("docx_numbered_lines", "docx"):
+            parsed = docx_numbered_lines.parse_docx_numbered_lines(fpath)
+        elif mode == "docx_paragraphs":
+            parsed = docx_paragraphs.parse_docx_paragraphs(fpath)
+        elif mode in ("odt_numbered_lines", "odt"):
+            parsed = odt_numbered_lines.parse_odt_numbered_lines(fpath)
+        elif mode == "odt_paragraphs":
+            parsed = odt_paragraphs.parse_odt_paragraphs(fpath)
+        elif mode == "tei":
+            parsed = tei_importer.parse_tei(fpath)
         else:
             raise ValueError(f"Preview not supported for mode '{mode}'")
 
-        total = len(units_all)
-        return units_all[:limit], total
+        return to_preview(parsed.units, limit)
 
     def _handle_curate_exceptions_list(self, body: dict) -> None:
         """Return all curation exceptions for a given doc_id (or all if absent).

--- a/tests/importers/test_parse_layer.py
+++ b/tests/importers/test_parse_layer.py
@@ -1,0 +1,42 @@
+"""Direct tests for the shared parse layer (audit P0-1 / A-02).
+
+These test parse_<mode>() in isolation — the single parsing logic now shared by
+the importers (write path) and the sidecar /import/preview. Grows one block per
+importer as the parse/write split is rolled out.
+"""
+
+from __future__ import annotations
+
+from multicorpus_engine.importers.parsed import ParsedDoc, to_preview
+from multicorpus_engine.importers.txt import parse_txt_numbered_lines
+
+
+def test_parse_txt_numbered_lines(tmp_path) -> None:
+    p = tmp_path / "doc.txt"
+    p.write_text("[1] Bonjour.\nIntertitre\n[2] Le monde.\n\n", encoding="utf-8")
+
+    parsed = parse_txt_numbered_lines(p)
+    assert isinstance(parsed, ParsedDoc)
+    assert parsed.doc_meta["encoding"] in ("utf-8", "ascii", "cp1252")  # detector choice
+    assert parsed.source_hash and len(parsed.source_hash) == 64
+
+    kinds = [(u.n, u.unit_type, u.external_id, u.text_raw) for u in parsed.units]
+    assert kinds == [
+        (1, "line", 1, "Bonjour."),
+        (2, "structure", None, "Intertitre"),
+        (3, "line", 2, "Le monde."),
+    ]
+    # structure unit gets the intertitre role; blank line skipped
+    assert parsed.units[1].unit_role == "intertitre"
+
+
+def test_to_preview_projection(tmp_path) -> None:
+    p = tmp_path / "doc.txt"
+    p.write_text("[1] one\n[2] two\n[3] three\n", encoding="utf-8")
+    parsed = parse_txt_numbered_lines(p)
+    preview, total = to_preview(parsed.units, limit=2)
+    assert total == 3
+    assert preview == [
+        {"n": 1, "external_id": 1, "unit_type": "line", "text_raw": "one"},
+        {"n": 2, "external_id": 2, "unit_type": "line", "text_raw": "two"},
+    ]

--- a/tests/importers/test_parse_layer.py
+++ b/tests/importers/test_parse_layer.py
@@ -1,16 +1,50 @@
 """Direct tests for the shared parse layer (audit P0-1 / A-02).
 
 These test parse_<mode>() in isolation — the single parsing logic now shared by
-the importers (write path) and the sidecar /import/preview. Grows one block per
-importer as the parse/write split is rolled out.
+the importers (write path) and the sidecar /import/preview — plus the core A-02
+guarantee: ``to_preview(parse_<mode>(f).units)`` must equal exactly what
+``import_<mode>(f)`` writes to the DB. If a future change makes the preview
+diverge from the import again, these break.
 """
 
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
+
+import pytest
+
 from multicorpus_engine.importers.parsed import ParsedDoc, to_preview
-from multicorpus_engine.importers.txt import parse_txt_numbered_lines
+from multicorpus_engine.importers.txt import (
+    import_txt_numbered_lines,
+    parse_txt_numbered_lines,
+)
+from multicorpus_engine.importers.docx_numbered_lines import (
+    import_docx_numbered_lines,
+    parse_docx_numbered_lines,
+)
+from multicorpus_engine.importers.docx_paragraphs import (
+    import_docx_paragraphs,
+    parse_docx_paragraphs,
+)
+from multicorpus_engine.importers.odt_numbered_lines import (
+    import_odt_numbered_lines,
+    parse_odt_numbered_lines,
+)
+from multicorpus_engine.importers.odt_paragraphs import (
+    import_odt_paragraphs,
+    parse_odt_paragraphs,
+)
+from multicorpus_engine.importers.tei_importer import import_tei, parse_tei
+from multicorpus_engine.importers.conllu import import_conllu, preview_conllu
+
+from tests.conftest import make_docx
+from tests.support_odt import make_odt_bytes
 
 
+# --------------------------------------------------------------------------- #
+# parse_<mode> in isolation
+# --------------------------------------------------------------------------- #
 def test_parse_txt_numbered_lines(tmp_path) -> None:
     p = tmp_path / "doc.txt"
     p.write_text("[1] Bonjour.\nIntertitre\n[2] Le monde.\n\n", encoding="utf-8")
@@ -40,3 +74,178 @@ def test_to_preview_projection(tmp_path) -> None:
         {"n": 1, "external_id": 1, "unit_type": "line", "text_raw": "one"},
         {"n": 2, "external_id": 2, "unit_type": "line", "text_raw": "two"},
     ]
+
+
+def test_parse_odt_numbered_lines(tmp_path) -> None:
+    p = tmp_path / "doc.odt"
+    p.write_bytes(make_odt_bytes(["[1] Bonjour.", "Intertitre", "[2] Le monde."]))
+
+    parsed = parse_odt_numbered_lines(p)
+    assert parsed.source_hash and len(parsed.source_hash) == 64
+    kinds = [(u.n, u.unit_type, u.external_id, u.text_raw) for u in parsed.units]
+    assert kinds == [
+        (1, "line", 1, "Bonjour."),
+        (2, "structure", None, "Intertitre"),
+        (3, "line", 2, "Le monde."),
+    ]
+    # ODT numbered-lines does NOT tag structure units with a role (unlike txt).
+    assert parsed.units[1].unit_role is None
+
+
+def test_parse_odt_paragraphs(tmp_path) -> None:
+    p = tmp_path / "doc.odt"
+    p.write_bytes(make_odt_bytes(["Premier.", "Deuxième."]))
+
+    parsed = parse_odt_paragraphs(p)
+    # Every non-empty paragraph is a line; position is both n and external_id.
+    kinds = [(u.n, u.unit_type, u.external_id, u.text_raw) for u in parsed.units]
+    assert kinds == [
+        (1, "line", 1, "Premier."),
+        (2, "line", 2, "Deuxième."),
+    ]
+
+
+def _tei_bytes() -> bytes:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<TEI xmlns="http://www.tei-c.org/ns/1.0">\n'
+        "  <teiHeader><fileDesc><titleStmt>"
+        "<title>Mon titre</title></titleStmt></fileDesc></teiHeader>\n"
+        '  <text xml:lang="fr"><body>\n'
+        '    <p xml:id="p5">Premier paragraphe.</p>\n'
+        "    <p>Deuxième sans id.</p>\n"
+        "  </body></text>\n"
+        "</TEI>\n"
+    ).encode("utf-8")
+
+
+def test_parse_tei_xmlid_and_fallback(tmp_path) -> None:
+    p = tmp_path / "doc.xml"
+    p.write_bytes(_tei_bytes())
+
+    parsed = parse_tei(p)
+    kinds = [(u.n, u.unit_type, u.external_id, u.text_raw) for u in parsed.units]
+    assert kinds == [
+        (1, "line", 5, "Premier paragraphe."),   # external_id from xml:id "p5"
+        (2, "line", 2, "Deuxième sans id."),      # FIX: falls back to n (was None in preview)
+    ]
+    # Header-derived metadata is carried in stats for the writer to apply.
+    assert parsed.stats["header_title"] == "Mon titre"
+    assert parsed.stats["header_lang"] == "fr"
+    assert isinstance(parsed.stats["validation_issues"], list)
+    assert parsed.doc_meta == {"tei_unit": "p"}
+
+
+# --------------------------------------------------------------------------- #
+# A-02 core guarantee: preview projection == what import writes to the DB
+# --------------------------------------------------------------------------- #
+def _db_units(conn: sqlite3.Connection, doc_id: int) -> list[dict]:
+    rows = conn.execute(
+        "SELECT n, external_id, unit_type, text_raw FROM units WHERE doc_id = ? ORDER BY n",
+        (doc_id,),
+    ).fetchall()
+    return [
+        {"n": r["n"], "external_id": r["external_id"],
+         "unit_type": r["unit_type"], "text_raw": r["text_raw"]}
+        for r in rows
+    ]
+
+
+def _assert_preview_equals_import(conn, path, import_fn, parse_fn, **import_kw) -> None:
+    report = import_fn(conn=conn, path=path, **import_kw)
+    preview, total = to_preview(parse_fn(path).units, limit=10_000)
+    assert preview == _db_units(conn, report.doc_id)
+    assert total == len(preview)
+
+
+def test_preview_matches_import_txt(db_conn, tmp_path) -> None:
+    p = tmp_path / "d.txt"
+    p.write_text("[1] alpha\nTitre\n[2] beta\n", encoding="utf-8")
+    _assert_preview_equals_import(
+        db_conn, p, import_txt_numbered_lines, parse_txt_numbered_lines, language="fr"
+    )
+
+
+def test_preview_matches_import_docx_numbered(db_conn, tmp_path) -> None:
+    p = tmp_path / "d.docx"
+    p.write_bytes(make_docx(["Intro", "[1] Bonjour.", "[2] Le chat¤le chien."]))
+    _assert_preview_equals_import(
+        db_conn, p, import_docx_numbered_lines, parse_docx_numbered_lines, language="fr"
+    )
+
+
+def test_preview_matches_import_docx_paragraphs(db_conn, tmp_path) -> None:
+    p = tmp_path / "d.docx"
+    p.write_bytes(make_docx(["Premier para.", "Deuxième para."]))
+    _assert_preview_equals_import(
+        db_conn, p, import_docx_paragraphs, parse_docx_paragraphs, language="fr"
+    )
+
+
+def test_preview_matches_import_odt_numbered(db_conn, tmp_path) -> None:
+    p = tmp_path / "d.odt"
+    p.write_bytes(make_odt_bytes(["Intro", "[1] Bonjour.", "[2] Le monde."]))
+    _assert_preview_equals_import(
+        db_conn, p, import_odt_numbered_lines, parse_odt_numbered_lines, language="fr"
+    )
+
+
+def test_preview_matches_import_odt_paragraphs(db_conn, tmp_path) -> None:
+    # Regression: the old sidecar ODT preview iterated (rich, level) tuples and
+    # passed them to normalize() — it 500'd. Going through parse_odt_paragraphs fixes it.
+    p = tmp_path / "d.odt"
+    p.write_bytes(make_odt_bytes(["Premier.", "Deuxième."]))
+    _assert_preview_equals_import(
+        db_conn, p, import_odt_paragraphs, parse_odt_paragraphs, language="fr"
+    )
+
+
+def test_preview_matches_import_tei(db_conn, tmp_path) -> None:
+    p = tmp_path / "d.xml"
+    p.write_bytes(_tei_bytes())
+    # language=None so the importer uses the header-derived lang, like the preview.
+    _assert_preview_equals_import(db_conn, p, import_tei, parse_tei)
+
+
+# --------------------------------------------------------------------------- #
+# CoNLL-U: lenient preview vs strict import
+# --------------------------------------------------------------------------- #
+_MALFORMED_CONLLU = (
+    "# sent_id = 1\n"
+    "# text = Du calme.\n"
+    "1\tDe\tde\tADP\t_\t_\t0\troot\t_\t_\n"
+    "2\tle\tle\tDET\t_\t_\t1\tdet\t_\t_\n"
+    "BADLINE_WITHOUT_TABS\n"
+    "3\tcalme\tcalme\tNOUN\t_\t_\t1\tobj\t_\t_\n"
+    "\n"
+)
+
+
+def test_preview_conllu_is_lenient(tmp_path) -> None:
+    p = tmp_path / "d.conllu"
+    p.write_text(_MALFORMED_CONLLU, encoding="utf-8")
+
+    stats = preview_conllu(p, limit=100)
+    assert stats["sentences"] == 1
+    assert stats["tokens"] == 3
+    assert stats["malformed_lines"] == 1   # counted, NOT raised
+    assert stats["skipped_ranges"] == 0
+    assert stats["sample_rows"][0] == {
+        "sent": 1, "id": "1", "form": "De", "lemma": "de", "upos": "ADP",
+    }
+
+
+def test_import_conllu_is_strict_on_same_file(db_conn, tmp_path) -> None:
+    # The strict importer rejects what the lenient preview merely counts.
+    p = tmp_path / "d.conllu"
+    p.write_text(_MALFORMED_CONLLU, encoding="utf-8")
+    with pytest.raises(ValueError):
+        import_conllu(conn=db_conn, path=p, language="fr")
+
+
+def test_preview_conllu_sample_limit(tmp_path) -> None:
+    p = tmp_path / "d.conllu"
+    p.write_text(_MALFORMED_CONLLU, encoding="utf-8")
+    stats = preview_conllu(p, limit=2)
+    assert len(stats["sample_rows"]) == 2   # capped at limit
+    assert stats["tokens"] == 3             # counts are unaffected by the sample cap

--- a/tests/importers/test_parse_layer.py
+++ b/tests/importers/test_parse_layer.py
@@ -10,7 +10,6 @@ diverge from the import again, these break.
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_sidecar_import_preview.py
+++ b/tests/test_sidecar_import_preview.py
@@ -9,6 +9,9 @@ from urllib.request import Request, urlopen
 
 import pytest
 
+from tests.conftest import make_docx
+from tests.support_odt import make_odt_bytes
+
 
 # ─── HTTP helpers ─────────────────────────────────────────────────────────────
 
@@ -186,7 +189,7 @@ def test_preview_nonexistent_file_returns_404(preview_sidecar):
 
 
 def test_preview_non_conllu_mode_returns_null_stats(preview_sidecar):
-    """Non-conllu mode → ok=True, conllu_stats=None (no text preview implemented)."""
+    """Non-conllu mode → ok=True, conllu_stats=None, and a units payload (A-02)."""
     base_url, tmp_path = preview_sidecar
     f = tmp_path / "doc.txt"
     f.write_text("Hello world\n", encoding="utf-8")
@@ -197,3 +200,82 @@ def test_preview_non_conllu_mode_returns_null_stats(preview_sidecar):
     assert code == 200
     assert body["ok"] is True
     assert body["conllu_stats"] is None
+    # A non-numbered line is a structure unit (not a line) — the preview now
+    # surfaces that, exactly like the import.
+    assert body["units"] == [
+        {"n": 1, "external_id": None, "unit_type": "structure", "text_raw": "Hello world"},
+    ]
+    assert body["units_total"] == 1
+    assert body["truncated"] is False
+
+
+# ─── A-02: text-mode preview goes through parse_<mode> over HTTP ────────────────
+# These exercise the sidecar dispatch wiring per mode (the parse output itself is
+# pinned in tests/importers/test_parse_layer.py). Expected payloads are what
+# parse_<mode>() produces, so preview MUST equal import.
+
+def test_txt_preview_units(preview_sidecar):
+    base_url, tmp_path = preview_sidecar
+    f = tmp_path / "d.txt"
+    f.write_text("[1] alpha\nTitre\n[2] beta\n", encoding="utf-8")
+    code, body = _post(f"{base_url}/import/preview", {"path": str(f), "mode": "txt", "limit": 2})
+    assert code == 200, body
+    assert body["units"] == [
+        {"n": 1, "external_id": 1, "unit_type": "line", "text_raw": "alpha"},
+        {"n": 2, "external_id": None, "unit_type": "structure", "text_raw": "Titre"},
+    ]
+    assert body["units_total"] == 3
+    assert body["truncated"] is True   # 3 > limit 2
+
+
+def test_docx_preview_units_labels_structure(preview_sidecar):
+    # Pins the A-02 fix: a non-numbered docx paragraph is "structure"/None
+    # (the old preview wrongly reported it as "line"/external_id=n).
+    base_url, tmp_path = preview_sidecar
+    f = tmp_path / "d.docx"
+    f.write_bytes(make_docx(["Intro", "[1] Bonjour.", "[2] Le chat¤le chien."]))
+    code, body = _post(f"{base_url}/import/preview", {"path": str(f), "mode": "docx_numbered_lines"})
+    assert code == 200, body
+    assert body["units"] == [
+        {"n": 1, "external_id": None, "unit_type": "structure", "text_raw": "Intro"},
+        {"n": 2, "external_id": 1, "unit_type": "line", "text_raw": "Bonjour."},
+        {"n": 3, "external_id": 2, "unit_type": "line", "text_raw": "Le chat¤le chien."},
+    ]
+
+
+def test_odt_preview_units_not_broken(preview_sidecar):
+    # Pins the A-02 fix: the old ODT preview iterated (rich, level) tuples into
+    # normalize() and 500'd. Going through parse_odt_numbered_lines fixes it.
+    base_url, tmp_path = preview_sidecar
+    f = tmp_path / "d.odt"
+    f.write_bytes(make_odt_bytes(["Intro", "[1] Bonjour.", "[2] Le monde."]))
+    code, body = _post(f"{base_url}/import/preview", {"path": str(f), "mode": "odt_numbered_lines"})
+    assert code == 200, body
+    assert body["units"] == [
+        {"n": 1, "external_id": None, "unit_type": "structure", "text_raw": "Intro"},
+        {"n": 2, "external_id": 1, "unit_type": "line", "text_raw": "Bonjour."},
+        {"n": 3, "external_id": 2, "unit_type": "line", "text_raw": "Le monde."},
+    ]
+
+
+def test_tei_preview_units_xmlid_fallback(preview_sidecar):
+    # Pins the A-02 fix: external_id falls back to n when xml:id has no trailing
+    # digit (the old preview left it None).
+    base_url, tmp_path = preview_sidecar
+    f = tmp_path / "d.xml"
+    f.write_bytes(
+        b'<?xml version="1.0" encoding="UTF-8"?>\n'
+        b'<TEI xmlns="http://www.tei-c.org/ns/1.0">\n'
+        b"  <teiHeader><fileDesc><titleStmt><title>T</title></titleStmt></fileDesc></teiHeader>\n"
+        b'  <text xml:lang="fr"><body>\n'
+        b'    <p xml:id="p5">Premier.</p>\n'
+        b"    <p>Deuxieme.</p>\n"
+        b"  </body></text>\n"
+        b"</TEI>\n"
+    )
+    code, body = _post(f"{base_url}/import/preview", {"path": str(f), "mode": "tei"})
+    assert code == 200, body
+    assert body["units"] == [
+        {"n": 1, "external_id": 5, "unit_type": "line", "text_raw": "Premier."},
+        {"n": 2, "external_id": 2, "unit_type": "line", "text_raw": "Deuxieme."},
+    ]


### PR DESCRIPTION
## But — ferme A-02 (audit 2026-06-12)

`/import/preview` réimplémentait le parsing des importers (`_preview_text_units` + bloc CoNLL-U inline) → dérive possible entre ce que le preview montre et ce que l'import écrit. Ce PR fait du `parse_<mode>() -> ParsedDoc` la **source unique**, partagée par le write-path ET le preview.

## Contenu

**Couche parse (importers/)**
- Splits ajoutés ce tranche : `parse_odt_numbered_lines`, `parse_odt_paragraphs`, `parse_tei` (txt/docx×2 déjà faits en 1a/1b).
- `conllu.preview_conllu(path, limit)` : scan *lenient* du preview déplacé hors du sidecar, **délibérément distinct** du strict `_parse_conllu` (compte les lignes malformées, ne lève pas — le strict rejette).
- Q-03 clos : `file_sha256` unique dans `parsed.py`, 7 importers l'utilisent.

**Sidecar**
- `/import/preview` dispatche chaque mode texte vers `parse_<mode>() + to_preview()`. `_preview_text_units` (~95 l. réimplémentées) et le bloc CoNLL-U inline supprimés. **`sidecar.py` : −142 lignes nettes.**

## ⚠️ Changements de comportement (à relire) — le preview montre désormais EXACTEMENT ce que l'import écrit

Trois dérives préexistantes que la duplication masquait, maintenant corrigées :
1. **docx numérotés** : strip du préfixe `[n]` — le preview faisait `.strip()`+`startswith`, l'import slice `rich[prefix_len:]`. Unifié sur l'import.
2. **TEI** : `external_id` retombe sur `n` quand `xml:id` n'a pas de suffixe numérique (le preview renvoyait `None`).
3. **ODT preview** : était **cassé** (itérait des tuples `(rich, level)` dans `normalize()` → 500). Réparé.

## Tests
- `tests/importers/test_parse_layer.py` : +14 tests, dont un **garde-fou d'équivalence `preview == import` par mode** (régression-guard contre toute future re-divergence) + couverture lenient-vs-strict CoNLL-U.
- Suite non-sidecar : **466 passent**. CI : Python tests & contract freeze ✅, ruff ✅, builds ✅.
- `growth-gate` ❌ = advisory (cumul 90j de `sidecar.py`, pas ce PR qui en retire 142) — pas d'override.

## Tracker
A-02 et Q-03 déplacés en *Traités* dans `docs/AUDIT_FOLLOW_UP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)