### PR TITLE
fix(webdav): strip Authorization on cross-origin redirects

### DIFF
--- a/src/multicorpus_engine/remote/webdav.py
+++ b/src/multicorpus_engine/remote/webdav.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Optional
 from urllib.error import HTTPError, URLError
 from urllib.parse import unquote, urljoin, urlsplit
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 import defusedxml.ElementTree as ET
 
@@ -127,6 +127,45 @@ def _same_origin(base: str, other: str) -> bool:
         and (b.hostname or "").lower() == (o.hostname or "").lower()
         and _port(b) == _port(o)
     )
+
+
+class _AuthStrippingRedirectHandler(HTTPRedirectHandler):
+    """Follow redirects, but drop the ``Authorization`` header on cross-origin hops.
+
+    urllib's default handler re-sends every request header — including
+    ``Authorization`` — to the redirect target, even when it points to a
+    different host. A malicious/compromised WebDAV server could thus 30x the
+    download GET to an attacker host and harvest the credentials. We strip
+    ``Authorization`` whenever the next URL is not same-origin with the request
+    being redirected; legitimate same-origin redirects (e.g. a Nextcloud
+    trailing-slash 301) keep it and still work.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new is not None and not _same_origin(req.full_url, newurl):
+            new.headers = {
+                k: v for k, v in new.headers.items() if k.lower() != "authorization"
+            }
+            new.unredirected_hdrs = {
+                k: v for k, v in new.unredirected_hdrs.items() if k.lower() != "authorization"
+            }
+            log.warning(
+                "WebDAV: stripped Authorization on cross-origin redirect %s -> %s",
+                req.full_url, newurl,
+            )
+        return new
+
+
+# Module HTTP opener: follows redirects but strips credentials on cross-origin
+# hops (see _AuthStrippingRedirectHandler). Every WebDAV request goes through it
+# via the urlopen() wrapper below (which is also the test seam).
+_OPENER = build_opener(_AuthStrippingRedirectHandler())
+
+
+def urlopen(req: Request, timeout: int):
+    """Open *req* through the credential-stripping opener (test seam)."""
+    return _OPENER.open(req, timeout=timeout)
 
 
 def propfind(url: str, *, auth_header: dict, timeout: int = DEFAULT_TIMEOUT) -> list[RemoteEntry]:

--- a/tests/test_webdav_client.py
+++ b/tests/test_webdav_client.py
@@ -5,9 +5,11 @@ Network is mocked at ``urlopen``; no real server is contacted.
 
 from __future__ import annotations
 
+import email.message
 from pathlib import Path
 from unittest import mock
 from urllib.error import HTTPError, URLError
+from urllib.request import Request
 
 import pytest
 
@@ -229,3 +231,53 @@ def test_download_rejects_oversize_streamed_without_header(tmp_path: Path):
         with pytest.raises(webdav.WebdavTooLarge):
             webdav.download("https://dav.example/f", dest, auth_header={}, max_bytes=10)
     assert not dest.exists()
+
+
+# --- redirect credential stripping ----------------------------------------------
+# urllib's default redirect handler re-sends Authorization to the redirect target,
+# even cross-host. _AuthStrippingRedirectHandler must drop it on any non-same-origin
+# hop so a malicious 30x cannot exfiltrate the WebDAV credentials.
+
+_SRC = "https://dav.example/folder/a.docx"
+
+
+def _do_redirect(new_url: str, *, method: str = "GET", code: int = 302):
+    handler = webdav._AuthStrippingRedirectHandler()
+    req = Request(_SRC, method=method, headers={"Authorization": "Basic SECRET", "Depth": "1"})
+    return handler.redirect_request(req, None, code, "Found", email.message.Message(), new_url)
+
+
+def _has_auth(req) -> bool:
+    return any(k.lower() == "authorization" for k in req.headers) or any(
+        k.lower() == "authorization" for k in req.unredirected_hdrs
+    )
+
+
+@pytest.mark.parametrize("new_url", [
+    "https://attacker.example/steal",          # different host
+    "http://dav.example/folder/a.docx",        # scheme downgrade https -> http
+    "https://dav.example:8443/folder/a.docx",  # different port
+])
+def test_redirect_strips_auth_cross_origin(new_url):
+    new = _do_redirect(new_url)
+    assert new is not None
+    assert not _has_auth(new), f"Authorization leaked to {new_url}"
+
+
+def test_redirect_keeps_auth_same_origin():
+    # A legitimate same-origin redirect (e.g. trailing-slash 301) keeps credentials.
+    new = _do_redirect("https://dav.example/folder/other.docx")
+    assert _has_auth(new)
+
+
+def test_redirect_strips_only_auth_not_other_headers():
+    new = _do_redirect("https://attacker.example/x")
+    assert not _has_auth(new)
+    assert any(k.lower() == "depth" for k in new.headers)  # non-sensitive header survives
+
+
+def test_module_opener_wires_the_auth_stripping_handler():
+    # Guards that production requests actually go through the hardened handler.
+    assert any(
+        isinstance(h, webdav._AuthStrippingRedirectHandler) for h in webdav._OPENER.handlers
+    )


### PR DESCRIPTION
## Bug (security)

`multicorpus_engine.remote.webdav` builds an `Authorization` header (Basic/Bearer) and passes it to `urllib`. urllib's default `HTTPRedirectHandler` **re-sends every request header — including `Authorization` — to the redirect target, even across hosts**. A malicious or compromised WebDAV server could `30x` the `download()` GET to an attacker-controlled host and harvest the credentials (and/or SSRF the client).

The same-origin **href** guard shipped with ShareDocs only filters PROPFIND listing entries — it does **not** cover the HTTP redirect vector.

## Fix

All WebDAV requests now go through an opener whose redirect handler (`_AuthStrippingRedirectHandler`) **drops `Authorization` whenever the next URL is not same-origin** (scheme/host/port — reuses `_same_origin`) with the request being redirected. Same-origin redirects (e.g. a Nextcloud trailing-slash `301`) keep the header and still work.

- PROPFIND is not auto-redirected by urllib (method ∉ GET/HEAD/POST → it raises), so the GET in `download()` is the real vector; it's now covered.
- A module-level `urlopen()` wrapper keeps the existing test seam → **no `install_opener` global side effect**, and the 8 mocked tests are unchanged.

## Tests (all run locally — pure redirect logic, no server)

- cross-host / scheme-downgrade (https→http) / cross-port → `Authorization` stripped
- same-origin → kept
- non-sensitive header (`Depth`) survives the strip
- guard that `_OPENER` is actually wired with the hardened handler

472 non-sidecar tests pass; ruff `src tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)