### PR TITLE
refactor(P0-1/A-01): extract conventions into a service

### DIFF
--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -41,7 +41,7 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 
 | ID | Sév | Prio | Statut | Constat (résumé) |
 |----|-----|------|--------|------------------|
-| A-01 | 🔴 | P0-1 | ⬜ ouvert | `sidecar.py` monolithe (9 961 l., 93 handlers, pas de couche services) |
+| A-01 | 🔴 | P0-1 | 🟦 partiel | `sidecar.py` monolithe. Couche `services/` amorcée : `import_service` (tranche-1a, #46) + `conventions_service` (CRUD unit_roles + `ConflictError`). Handlers→adapters fins (lock + map erreurs + envelope, réponses byte-identiques). Domaines restants : align/segment/curate/export/documents/doc_relations… |
 | A-03 | 🟠 | P0-1 | ⬜ ouvert | 66 blocs de validation manuelle (pas de validateur de schéma) |
 | A-04 | 🟡 | P2-13 | ⬜ ouvert | Attributs dynamiques non typés sur `HTTPServer` |
 | Q-02 | 🟠 | P0-1 | ⬜ ouvert | Fonctions géantes ; `_build_hits` vs `_build_hits_regex` (~70 l. dupliquées) |

--- a/src/multicorpus_engine/services/conventions_service.py
+++ b/src/multicorpus_engine/services/conventions_service.py
@@ -1,0 +1,199 @@
+"""Conventions (unit_roles) domain service — audit P0-1 / A-01.
+
+CRUD over the ``unit_roles`` table, extracted verbatim from the sidecar
+``_handle_conventions_*`` handlers so the validation + SQL live here (and can be
+tested without a running HTTP server). Each function is pure w.r.t. transport: it
+takes a connection + the request inputs, mutates the DB, and returns response
+*data* — no HTTP envelope. The sidecar adapter owns the write-lock and maps
+:class:`ServiceError` to wire codes, so responses stay byte-identical.
+
+The per-function ``category`` fallbacks intentionally differ (matching the
+original handlers): ``list``/``update`` fall back to ``"text"`` for a
+non-structure role on a pre-``category`` schema, whereas ``create`` falls back to
+the supplied (coerced) input category.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from .errors import ConflictError, NotFoundError, ValidationError
+
+# Role names treated as "structure" when the unit_roles table predates the
+# `category` column (schema tolerance). Canonical home for this set.
+STRUCTURE_ROLE_NAMES = frozenset({
+    "titre", "intertitre", "dedicace", "epigraphe", "incipit",
+    "colophon", "preface", "postface", "note", "paratext",
+})
+
+
+def _has_category(conn: sqlite3.Connection) -> bool:
+    """True if the unit_roles table has the (newer) ``category`` column."""
+    return "category" in {
+        row[1] for row in conn.execute("PRAGMA table_info(unit_roles)").fetchall()
+    }
+
+
+def _project(row: sqlite3.Row, category: str) -> dict[str, Any]:
+    """Shape one unit_roles row as a convention dict (category passed explicitly
+    because the fallback rule differs per operation)."""
+    return {
+        "role_id": row["role_id"],
+        "name": row["name"],
+        "label": row["label"],
+        "color": row["color"],
+        "icon": row["icon"],
+        "sort_order": row["sort_order"],
+        "category": category,
+        "created_at": row["created_at"],
+    }
+
+
+def list_conventions(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Return every unit role (GET /conventions)."""
+    has_cat = _has_category(conn)
+    if has_cat:
+        rows = conn.execute(
+            "SELECT role_id, name, label, color, icon, sort_order, category, created_at"
+            " FROM unit_roles ORDER BY sort_order ASC, role_id ASC"
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT role_id, name, label, color, icon, sort_order, created_at"
+            " FROM unit_roles ORDER BY sort_order ASC, role_id ASC"
+        ).fetchall()
+
+    def _cat(r: sqlite3.Row) -> str:
+        if has_cat:
+            return r["category"] or "text"
+        return "structure" if r["name"] in STRUCTURE_ROLE_NAMES else "text"
+
+    return [_project(r, _cat(r)) for r in rows]
+
+
+def create_convention(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """Create a new unit role (POST /conventions). Returns the created convention.
+
+    Raises ValidationError (bad input) or ConflictError (name already exists).
+    """
+    name = (body.get("name") or "").strip()
+    label = (body.get("label") or "").strip()
+    color = (body.get("color") or "#6366f1").strip()
+    icon = body.get("icon")
+    sort_order = body.get("sort_order", 0)
+    category = (body.get("category") or "text").strip()
+    if category not in ("structure", "text"):
+        category = "text"
+
+    if not name:
+        raise ValidationError("name is required")
+    if not label:
+        raise ValidationError("label is required")
+    if not name.replace("_", "").replace("-", "").isalnum():
+        raise ValidationError(
+            "name must contain only letters, digits, hyphens and underscores"
+        )
+
+    existing = conn.execute(
+        "SELECT role_id FROM unit_roles WHERE name=?", (name,)
+    ).fetchone()
+    if existing:
+        raise ConflictError(f"Convention '{name}' already exists")
+
+    has_cat = _has_category(conn)
+    if has_cat:
+        conn.execute(
+            "INSERT INTO unit_roles (name, label, color, icon, sort_order, category)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (name, label, color, icon, int(sort_order), category),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO unit_roles (name, label, color, icon, sort_order)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (name, label, color, icon, int(sort_order)),
+        )
+    conn.commit()
+
+    sel_cols = "role_id, name, label, color, icon, sort_order, created_at"
+    if has_cat:
+        sel_cols = "role_id, name, label, color, icon, sort_order, category, created_at"
+    row = conn.execute(
+        f"SELECT {sel_cols} FROM unit_roles WHERE name=?", (name,)
+    ).fetchone()
+    row_cat = row["category"] if has_cat else (
+        "structure" if name in STRUCTURE_ROLE_NAMES else category
+    )
+    return _project(row, row_cat)
+
+
+def update_convention(
+    conn: sqlite3.Connection, role_name: str, body: dict
+) -> dict[str, Any]:
+    """Update label/color/icon/sort_order (+category) of a role (PUT /conventions/<name>).
+
+    Raises ValidationError (no path name / no updatable field) or NotFoundError.
+    """
+    if not role_name:
+        raise ValidationError("role name required in path")
+
+    row = conn.execute(
+        "SELECT role_id FROM unit_roles WHERE name=?", (role_name,)
+    ).fetchone()
+    if not row:
+        raise NotFoundError(f"Convention '{role_name}' not found")
+
+    has_cat_up = _has_category(conn)
+    updatable = ("label", "color", "icon", "sort_order") + (("category",) if has_cat_up else ())
+    fields: list[str] = []
+    params: list[object] = []
+    for col in updatable:
+        if col in body:
+            val = body[col]
+            if col == "category" and val not in ("structure", "text"):
+                val = "text"
+            fields.append(f"{col}=?")
+            params.append(val)
+    if not fields:
+        raise ValidationError(
+            "At least one of label, color, icon, sort_order, category must be provided"
+        )
+
+    params.append(role_name)
+    conn.execute(f"UPDATE unit_roles SET {', '.join(fields)} WHERE name=?", params)
+    conn.commit()
+
+    sel_cols_up = "role_id, name, label, color, icon, sort_order, created_at"
+    if has_cat_up:
+        sel_cols_up = "role_id, name, label, color, icon, sort_order, category, created_at"
+    updated = conn.execute(
+        f"SELECT {sel_cols_up} FROM unit_roles WHERE name=?", (role_name,)
+    ).fetchone()
+    updated_cat = updated["category"] if has_cat_up else (
+        "structure" if role_name in STRUCTURE_ROLE_NAMES else "text"
+    )
+    return _project(updated, updated_cat)
+
+
+def delete_convention(conn: sqlite3.Connection, body: dict) -> str:
+    """Delete a role; units carrying it become NULL (POST /conventions/delete).
+
+    Returns the deleted name. Raises ValidationError or NotFoundError.
+    """
+    name = (body.get("name") or "").strip()
+    if not name:
+        raise ValidationError("name is required")
+
+    row = conn.execute(
+        "SELECT role_id FROM unit_roles WHERE name=?", (name,)
+    ).fetchone()
+    if not row:
+        raise NotFoundError(f"Convention '{name}' not found")
+
+    # ON DELETE SET NULL handles units via FK, but SQLite FK enforcement may be
+    # off; clear manually to be safe (verbatim from the original handler).
+    conn.execute("UPDATE units SET unit_role=NULL WHERE unit_role=?", (name,))
+    conn.execute("DELETE FROM unit_roles WHERE name=?", (name,))
+    conn.commit()
+    return name

--- a/src/multicorpus_engine/services/errors.py
+++ b/src/multicorpus_engine/services/errors.py
@@ -1,9 +1,13 @@
 """Service-layer error types (audit P0-1, A-03).
 
 Services raise these instead of touching HTTP. The sidecar adapter maps each to
-the frozen wire error code + status, so responses stay byte-identical:
-    ValidationError -> ERR_VALIDATION (400)
+the frozen wire error code + status, so responses stay byte-identical. The exact
+wire code is chosen per endpoint by the adapter (an endpoint may map
+ValidationError to ERR_VALIDATION or to ERR_BAD_REQUEST — whichever it historically
+returned), so the contract codes stay out of this module:
+    ValidationError -> ERR_VALIDATION / ERR_BAD_REQUEST (400)
     NotFoundError   -> ERR_NOT_FOUND  (404)
+    ConflictError   -> ERR_CONFLICT   (409)
 Keeping the contract codes in the adapter (not here) avoids coupling the service
 layer to the HTTP contract module.
 """
@@ -34,3 +38,9 @@ class NotFoundError(ServiceError):
     """A referenced entity does not exist. Maps to ERR_NOT_FOUND / 404."""
 
     http_status = 404
+
+
+class ConflictError(ServiceError):
+    """A uniqueness/state conflict (e.g. duplicate name). Maps to ERR_CONFLICT / 409."""
+
+    http_status = 409

--- a/src/multicorpus_engine/sidecar.py
+++ b/src/multicorpus_engine/sidecar.py
@@ -4655,212 +4655,60 @@ class _CorpusHandler(BaseHTTPRequestHandler):
     # ------------------------------------------------------------------
 
     # Names auto-assigned to 'structure' when category column is missing (pre-migration DBs).
-    _STRUCTURE_ROLE_NAMES = frozenset({
-        "titre", "intertitre", "dedicace", "epigraphe", "incipit",
-        "colophon", "preface", "postface", "note", "paratext",
-    })
-
     def _handle_conventions_list(self) -> None:
-        """GET /conventions — list all unit roles defined for this corpus."""
+        # Thin adapter over the conventions service (audit P0-1 / A-01).
+        from multicorpus_engine.services.conventions_service import list_conventions
         with self._lock():
-            conn = self._conn()
-            col_names = {row[1] for row in conn.execute("PRAGMA table_info(unit_roles)").fetchall()}
-            has_cat = "category" in col_names
-            if has_cat:
-                rows = conn.execute(
-                    "SELECT role_id, name, label, color, icon, sort_order, category, created_at"
-                    " FROM unit_roles ORDER BY sort_order ASC, role_id ASC"
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    "SELECT role_id, name, label, color, icon, sort_order, created_at"
-                    " FROM unit_roles ORDER BY sort_order ASC, role_id ASC"
-                ).fetchall()
-
-        def _cat(r: object) -> str:
-            if has_cat:
-                return r["category"] or "text"  # type: ignore[index]
-            return "structure" if r["name"] in self._STRUCTURE_ROLE_NAMES else "text"  # type: ignore[index]
-
+            conventions = list_conventions(self._conn())
         self._send_json(success_payload({
-            "conventions": [
-                {
-                    "role_id": r["role_id"],
-                    "name": r["name"],
-                    "label": r["label"],
-                    "color": r["color"],
-                    "icon": r["icon"],
-                    "sort_order": r["sort_order"],
-                    "category": _cat(r),
-                    "created_at": r["created_at"],
-                }
-                for r in rows
-            ],
-            "count": len(rows),
+            "conventions": conventions,
+            "count": len(conventions),
         }))
 
     def _handle_conventions_create(self, body: dict) -> None:
-        """POST /conventions — create a new unit role."""
-        name = (body.get("name") or "").strip()
-        label = (body.get("label") or "").strip()
-        color = (body.get("color") or "#6366f1").strip()
-        icon = body.get("icon")
-        sort_order = body.get("sort_order", 0)
-        category = (body.get("category") or "text").strip()
-        if category not in ("structure", "text"):
-            category = "text"
-
-        if not name:
-            self._send_error("name is required", code=ERR_BAD_REQUEST, http_status=400)
+        # Thin adapter over the conventions service. ValidationError keeps this
+        # endpoint's historic BAD_REQUEST code (not VALIDATION_ERROR).
+        from multicorpus_engine.services.conventions_service import create_convention
+        from multicorpus_engine.services.errors import ConflictError, ValidationError
+        try:
+            with self._lock():
+                convention = create_convention(self._conn(), body)
+        except ValidationError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-        if not label:
-            self._send_error("label is required", code=ERR_BAD_REQUEST, http_status=400)
+        except ConflictError as exc:
+            self._send_error(exc.message, code=ERR_CONFLICT, http_status=exc.http_status)
             return
-        if not name.replace("_", "").replace("-", "").isalnum():
-            self._send_error(
-                "name must contain only letters, digits, hyphens and underscores",
-                code=ERR_BAD_REQUEST, http_status=400,
-            )
-            return
-
-        with self._lock():
-            conn = self._conn()
-            existing = conn.execute(
-                "SELECT role_id FROM unit_roles WHERE name=?", (name,)
-            ).fetchone()
-            if existing:
-                self._send_error(
-                    f"Convention '{name}' already exists",
-                    code=ERR_CONFLICT, http_status=409,
-                )
-                return
-            col_names = {row[1] for row in conn.execute("PRAGMA table_info(unit_roles)").fetchall()}
-            if "category" in col_names:
-                conn.execute(
-                    "INSERT INTO unit_roles (name, label, color, icon, sort_order, category)"
-                    " VALUES (?, ?, ?, ?, ?, ?)",
-                    (name, label, color, icon, int(sort_order), category),
-                )
-            else:
-                conn.execute(
-                    "INSERT INTO unit_roles (name, label, color, icon, sort_order)"
-                    " VALUES (?, ?, ?, ?, ?)",
-                    (name, label, color, icon, int(sort_order)),
-                )
-            conn.commit()
-            sel_cols = "role_id, name, label, color, icon, sort_order, created_at"
-            if "category" in col_names:
-                sel_cols = "role_id, name, label, color, icon, sort_order, category, created_at"
-            row = conn.execute(
-                f"SELECT {sel_cols} FROM unit_roles WHERE name=?", (name,),
-            ).fetchone()
-            row_cat = row["category"] if "category" in col_names else (
-                "structure" if name in self._STRUCTURE_ROLE_NAMES else category
-            )
-
-        self._send_json(success_payload({
-            "convention": {
-                "role_id": row["role_id"],
-                "name": row["name"],
-                "label": row["label"],
-                "color": row["color"],
-                "icon": row["icon"],
-                "sort_order": row["sort_order"],
-                "category": row_cat,
-                "created_at": row["created_at"],
-            }
-        }), status=201)
+        self._send_json(success_payload({"convention": convention}), status=201)
 
     def _handle_conventions_update(self, role_name: str, body: dict) -> None:
-        """PUT /conventions/<name> — update label, color, icon, sort_order of a role."""
-        if not role_name:
-            self._send_error("role name required in path", code=ERR_BAD_REQUEST, http_status=400)
+        # Thin adapter over the conventions service.
+        from multicorpus_engine.services.conventions_service import update_convention
+        from multicorpus_engine.services.errors import NotFoundError, ValidationError
+        try:
+            with self._lock():
+                convention = update_convention(self._conn(), role_name, body)
+        except ValidationError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-
-        with self._lock():
-            conn = self._conn()
-            row = conn.execute(
-                "SELECT role_id FROM unit_roles WHERE name=?", (role_name,)
-            ).fetchone()
-            if not row:
-                self._send_error(
-                    f"Convention '{role_name}' not found",
-                    code=ERR_NOT_FOUND, http_status=404,
-                )
-                return
-
-            up_col_names = {row[1] for row in conn.execute("PRAGMA table_info(unit_roles)").fetchall()}
-            has_cat_up = "category" in up_col_names
-            updatable = ("label", "color", "icon", "sort_order") + (("category",) if has_cat_up else ())
-            fields: list[str] = []
-            params: list[object] = []
-            for col in updatable:
-                if col in body:
-                    val = body[col]
-                    if col == "category" and val not in ("structure", "text"):
-                        val = "text"
-                    fields.append(f"{col}=?")
-                    params.append(val)
-            if not fields:
-                self._send_error(
-                    "At least one of label, color, icon, sort_order, category must be provided",
-                    code=ERR_BAD_REQUEST, http_status=400,
-                )
-                return
-
-            params.append(role_name)
-            conn.execute(
-                f"UPDATE unit_roles SET {', '.join(fields)} WHERE name=?",
-                params,
-            )
-            conn.commit()
-            sel_cols_up = "role_id, name, label, color, icon, sort_order, created_at"
-            if has_cat_up:
-                sel_cols_up = "role_id, name, label, color, icon, sort_order, category, created_at"
-            updated = conn.execute(
-                f"SELECT {sel_cols_up} FROM unit_roles WHERE name=?", (role_name,),
-            ).fetchone()
-            updated_cat = updated["category"] if has_cat_up else (
-                "structure" if role_name in self._STRUCTURE_ROLE_NAMES else "text"
-            )
-
-        self._send_json(success_payload({
-            "convention": {
-                "role_id": updated["role_id"],
-                "name": updated["name"],
-                "label": updated["label"],
-                "color": updated["color"],
-                "icon": updated["icon"],
-                "sort_order": updated["sort_order"],
-                "category": updated_cat,
-                "created_at": updated["created_at"],
-            }
-        }))
+        except NotFoundError as exc:
+            self._send_error(exc.message, code=ERR_NOT_FOUND, http_status=exc.http_status)
+            return
+        self._send_json(success_payload({"convention": convention}))
 
     def _handle_conventions_delete(self, body: dict) -> None:
-        """POST /conventions/delete — delete a role; units with that role become NULL."""
-        name = (body.get("name") or "").strip()
-        if not name:
-            self._send_error("name is required", code=ERR_BAD_REQUEST, http_status=400)
+        # Thin adapter over the conventions service.
+        from multicorpus_engine.services.conventions_service import delete_convention
+        from multicorpus_engine.services.errors import NotFoundError, ValidationError
+        try:
+            with self._lock():
+                name = delete_convention(self._conn(), body)
+        except ValidationError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-
-        with self._lock():
-            conn = self._conn()
-            row = conn.execute(
-                "SELECT role_id FROM unit_roles WHERE name=?", (name,)
-            ).fetchone()
-            if not row:
-                self._send_error(
-                    f"Convention '{name}' not found",
-                    code=ERR_NOT_FOUND, http_status=404,
-                )
-                return
-            # ON DELETE SET NULL handles units automatically via FK
-            # but SQLite FK support may be off; clear manually to be safe
-            conn.execute("UPDATE units SET unit_role=NULL WHERE unit_role=?", (name,))
-            conn.execute("DELETE FROM unit_roles WHERE name=?", (name,))
-            conn.commit()
-
+        except NotFoundError as exc:
+            self._send_error(exc.message, code=ERR_NOT_FOUND, http_status=exc.http_status)
+            return
         self._send_json(success_payload({"deleted": name}))
 
     def _handle_units_set_role(self, body: dict) -> None:

--- a/tests/services/test_conventions_service.py
+++ b/tests/services/test_conventions_service.py
@@ -1,0 +1,141 @@
+"""Direct unit tests for the conventions service (audit P0-1 / A-01).
+
+These exercise the extracted unit_roles CRUD without any HTTP server — the point
+of the service-layer extraction. The migrated schema has the `category` column
+(migration 018), so the category-column path is the one under test here; the
+no-column fallback is legacy-only defensive code.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from multicorpus_engine.services.conventions_service import (
+    create_convention,
+    delete_convention,
+    list_conventions,
+    update_convention,
+)
+from multicorpus_engine.services.errors import (
+    ConflictError,
+    NotFoundError,
+    ValidationError,
+)
+
+
+# --- create ---------------------------------------------------------------------
+def test_create_returns_convention(db_conn: sqlite3.Connection) -> None:
+    conv = create_convention(
+        db_conn, {"name": "mycustom", "label": "My Custom", "category": "structure"}
+    )
+    assert isinstance(conv["role_id"], int)
+    assert conv["name"] == "mycustom"
+    assert conv["label"] == "My Custom"
+    assert conv["color"] == "#6366f1"           # default applied
+    assert conv["category"] == "structure"       # stored (category column present)
+    assert conv["created_at"]                     # NOT NULL default populated
+
+
+def test_create_conflict(db_conn: sqlite3.Connection) -> None:
+    create_convention(db_conn, {"name": "dup", "label": "Dup"})
+    with pytest.raises(ConflictError):
+        create_convention(db_conn, {"name": "dup", "label": "Dup again"})
+
+
+@pytest.mark.parametrize("body", [
+    {"label": "no name"},                         # missing name
+    {"name": "x", "label": ""},                   # missing label
+    {"name": "bad name!", "label": "L"},          # invalid chars in name
+])
+def test_create_validation(db_conn: sqlite3.Connection, body: dict) -> None:
+    with pytest.raises(ValidationError):
+        create_convention(db_conn, body)
+
+
+def test_create_category_coerced_to_text(db_conn: sqlite3.Connection) -> None:
+    conv = create_convention(db_conn, {"name": "weird", "label": "W", "category": "bogus"})
+    assert conv["category"] == "text"
+
+
+# --- list -----------------------------------------------------------------------
+def test_list_reflects_created(db_conn: sqlite3.Connection) -> None:
+    before = len(list_conventions(db_conn))
+    create_convention(db_conn, {"name": "listme", "label": "List Me"})
+    convs = list_conventions(db_conn)
+    assert len(convs) == before + 1
+    names = {c["name"] for c in convs}
+    assert "listme" in names
+    # every row is fully shaped
+    for c in convs:
+        assert set(c) == {
+            "role_id", "name", "label", "color", "icon",
+            "sort_order", "category", "created_at",
+        }
+
+
+# --- update ---------------------------------------------------------------------
+def test_update_changes_fields(db_conn: sqlite3.Connection) -> None:
+    create_convention(db_conn, {"name": "up", "label": "Old", "color": "#000000"})
+    conv = update_convention(db_conn, "up", {"label": "New", "color": "#ffffff"})
+    assert conv["label"] == "New"
+    assert conv["color"] == "#ffffff"
+    # persisted
+    again = update_convention(db_conn, "up", {"sort_order": 5})
+    assert again["sort_order"] == 5
+    assert again["label"] == "New"
+
+
+def test_update_not_found(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(NotFoundError):
+        update_convention(db_conn, "ghost", {"label": "x"})
+
+
+def test_update_requires_path_name(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(ValidationError):
+        update_convention(db_conn, "", {"label": "x"})
+
+
+def test_update_no_updatable_field(db_conn: sqlite3.Connection) -> None:
+    create_convention(db_conn, {"name": "nofields", "label": "L"})
+    with pytest.raises(ValidationError):
+        update_convention(db_conn, "nofields", {"irrelevant": 1})
+
+
+def test_update_category_coerced(db_conn: sqlite3.Connection) -> None:
+    create_convention(db_conn, {"name": "catup", "label": "L"})
+    conv = update_convention(db_conn, "catup", {"category": "nonsense"})
+    assert conv["category"] == "text"
+
+
+# --- delete ---------------------------------------------------------------------
+def test_delete_removes_role_and_clears_units(db_conn: sqlite3.Connection) -> None:
+    create_convention(db_conn, {"name": "mytag", "label": "My Tag"})
+    cur = db_conn.execute(
+        "INSERT INTO documents (title, language, doc_role, created_at)"
+        " VALUES ('D', 'fr', 'standalone', datetime('now'))"
+    )
+    doc_id = cur.lastrowid
+    db_conn.execute(
+        "INSERT INTO units (doc_id, unit_type, n, text_raw, text_norm, unit_role)"
+        " VALUES (?, 'line', 1, 'x', 'x', 'mytag')",
+        (doc_id,),
+    )
+    db_conn.commit()
+
+    assert delete_convention(db_conn, {"name": "mytag"}) == "mytag"
+    assert db_conn.execute("SELECT 1 FROM unit_roles WHERE name='mytag'").fetchone() is None
+    # the unit that carried the role is cleared to NULL, not deleted
+    role = db_conn.execute("SELECT unit_role FROM units WHERE doc_id=?", (doc_id,)).fetchone()[0]
+    assert role is None
+
+
+def test_delete_not_found(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(NotFoundError):
+        delete_convention(db_conn, {"name": "ghost"})
+
+
+def test_delete_name_required(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(ValidationError):
+        delete_convention(db_conn, {})


### PR DESCRIPTION
## A-01 — service-layer extraction, tranche 2 (after `import`)

The 4 `_handle_conventions_*` handlers (CRUD over `unit_roles`) become **thin adapters**; the validation + SQL move into `services/conventions_service.py` (`list/create/update/delete`), raising typed errors. The adapter owns the write-lock and the HTTP envelope.

### Changes
- **`services/conventions_service.py`** (new): pure CRUD, raises `ValidationError` / `ConflictError` / `NotFoundError`. Canonical `STRUCTURE_ROLE_NAMES` set lives here now (the sidecar class attribute is removed — it was used only by these handlers).
- **`services/errors.py`**: adds `ConflictError` (409) to the vocabulary (reusable by future tranches).
- **`sidecar.py`**: 4 handlers → adapters.

### Byte-identical preservation
- This endpoint historically returned **`BAD_REQUEST`** (not `VALIDATION_ERROR`) for bad input, so the adapter maps `ValidationError → ERR_BAD_REQUEST`, `ConflictError → ERR_CONFLICT`, `NotFoundError → ERR_NOT_FOUND`.
- The per-operation `category` fallback nuances (create falls back to the input category; list/update fall back to `"text"`) are kept verbatim.
- Create still returns `201`; response shapes (`{conventions,count}`, `{convention}`, `{deleted}`) unchanged.

### Tests
- **`tests/services/test_conventions_service.py`** (15 tests) — runs **locally** via `db_conn`, no HTTP server (the point of the extraction).
- **`tests/test_sidecar_conventions.py`** (existing) keeps covering the HTTP adapter end-to-end in CI — its assertions (`201`, `409`, `400`, shapes) match the preserved behavior.
- 487 non-sidecar tests pass; ruff `src tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)