### PR TITLE
refactor(P0-1/A-01): extract doc_relations CRUD into a service

### DIFF
--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -41,7 +41,7 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 
 | ID | Sév | Prio | Statut | Constat (résumé) |
 |----|-----|------|--------|------------------|
-| A-01 | 🔴 | P0-1 | 🟦 partiel | `sidecar.py` monolithe. Couche `services/` amorcée : `import_service` (tranche-1a, #46) + `conventions_service` (CRUD unit_roles + `ConflictError`). Handlers→adapters fins (lock + map erreurs + envelope, réponses byte-identiques). Domaines restants : align/segment/curate/export/documents/doc_relations… |
+| A-01 | 🔴 | P0-1 | 🟦 partiel | `sidecar.py` monolithe. Couche `services/` : `import_service` (#46) + `conventions_service` (#50, +`ConflictError`) + `doc_relations_service` (CRUD relations de famille). Handlers→adapters fins (lock pour les writes, map erreurs, envelope ; réponses byte-identiques). Filet : smoke-run binaire en CI (#51) frappe un GET par couche service. Domaines restants : align/segment/curate/export/documents… |
 | A-03 | 🟠 | P0-1 | ⬜ ouvert | 66 blocs de validation manuelle (pas de validateur de schéma) |
 | A-04 | 🟡 | P2-13 | ⬜ ouvert | Attributs dynamiques non typés sur `HTTPServer` |
 | Q-02 | 🟠 | P0-1 | ⬜ ouvert | Fonctions géantes ; `_build_hits` vs `_build_hits_regex` (~70 l. dupliquées) |

--- a/scripts/smoke_sidecar.py
+++ b/scripts/smoke_sidecar.py
@@ -30,7 +30,8 @@ from pathlib import Path
 
 # (path, expected key in the JSON body) — one public GET per extracted service.
 CHECKS: list[tuple[str, str]] = [
-    ("/conventions", "conventions"),  # conventions_service
+    ("/conventions", "conventions"),       # conventions_service
+    ("/doc_relations/all", "relations"),   # doc_relations_service
 ]
 
 

--- a/src/multicorpus_engine/services/doc_relations_service.py
+++ b/src/multicorpus_engine/services/doc_relations_service.py
@@ -1,0 +1,105 @@
+"""Document-relations domain service — audit P0-1 / A-01.
+
+CRUD over the ``doc_relations`` table (the meta-links translation_of / excerpt_of
+that bind documents into families), extracted verbatim from the sidecar
+``_handle_doc_relations_*`` handlers. Pure w.r.t. transport: each function takes a
+connection + request inputs, mutates the DB, and returns the response *data*. The
+sidecar adapter owns the write-lock (writes only) and the HTTP envelope, and maps
+:class:`ValidationError` to the endpoint's historic ``BAD_REQUEST`` wire code.
+
+Reads (``get`` / ``list_all``) do NOT take the write-lock — matching the original
+handlers.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Optional
+
+from .errors import ValidationError
+
+_SELECT_COLS = "id, doc_id, relation_type, target_doc_id, note, created_at"
+
+
+def _row_to_relation(r: sqlite3.Row | tuple) -> dict[str, Any]:
+    return {
+        "id": r[0], "doc_id": r[1], "relation_type": r[2],
+        "target_doc_id": r[3], "note": r[4], "created_at": r[5],
+    }
+
+
+def get_doc_relations(conn: sqlite3.Connection, doc_id_raw: Optional[str]) -> dict[str, Any]:
+    """Relations declared *by* one document (GET /doc_relations?doc_id=).
+
+    ``doc_id_raw`` is the raw query-param value (str or None). Raises
+    ValidationError (required / not an integer).
+    """
+    if doc_id_raw is None:
+        raise ValidationError("doc_id query param is required")
+    try:
+        doc_id = int(doc_id_raw)
+    except (TypeError, ValueError):
+        raise ValidationError("doc_id must be an integer")
+
+    rows = conn.execute(
+        f"SELECT {_SELECT_COLS} FROM doc_relations WHERE doc_id = ? ORDER BY id",
+        (doc_id,),
+    ).fetchall()
+    relations = [_row_to_relation(r) for r in rows]
+    return {"doc_id": doc_id, "relations": relations, "count": len(relations)}
+
+
+def list_all_doc_relations(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Every doc_relation row in the corpus (GET /doc_relations/all)."""
+    rows = conn.execute(
+        f"SELECT {_SELECT_COLS} FROM doc_relations ORDER BY doc_id, id"
+    ).fetchall()
+    relations = [_row_to_relation(r) for r in rows]
+    return {"relations": relations, "count": len(relations)}
+
+
+def set_doc_relation(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """Create or update a relation (POST /doc_relations/set).
+
+    Upsert on (doc_id, relation_type, target_doc_id): if it exists, only the note
+    is updated. Raises ValidationError if any of the three keys is missing.
+    """
+    doc_id = body.get("doc_id")
+    relation_type = body.get("relation_type")
+    target_doc_id = body.get("target_doc_id")
+    if doc_id is None or not relation_type or target_doc_id is None:
+        raise ValidationError("doc_id, relation_type, and target_doc_id are required")
+    note = body.get("note")
+
+    existing = conn.execute(
+        "SELECT id FROM doc_relations WHERE doc_id = ? AND relation_type = ? AND target_doc_id = ?",
+        (doc_id, relation_type, target_doc_id),
+    ).fetchone()
+    if existing:
+        conn.execute("UPDATE doc_relations SET note = ? WHERE id = ?", (note, existing[0]))
+        rel_id = existing[0]
+        action = "updated"
+    else:
+        cur = conn.execute(
+            "INSERT INTO doc_relations (doc_id, relation_type, target_doc_id, note, created_at)"
+            " VALUES (?, ?, ?, ?, datetime('now'))",
+            (doc_id, relation_type, target_doc_id, note),
+        )
+        rel_id = cur.lastrowid
+        action = "created"
+    conn.commit()
+    return {
+        "action": action, "id": rel_id, "doc_id": doc_id,
+        "relation_type": relation_type, "target_doc_id": target_doc_id,
+    }
+
+
+def delete_doc_relation(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """Delete a relation by id (POST /doc_relations/delete). Raises ValidationError
+    if ``id`` is missing. Returns the number of rows deleted (0 if no match)."""
+    rel_id = body.get("id")
+    if rel_id is None:
+        raise ValidationError("id is required")
+    cur = conn.execute("DELETE FROM doc_relations WHERE id = ?", (rel_id,))
+    conn.commit()
+    return {"deleted": cur.rowcount}

--- a/src/multicorpus_engine/sidecar.py
+++ b/src/multicorpus_engine/sidecar.py
@@ -6432,41 +6432,25 @@ class _CorpusHandler(BaseHTTPRequestHandler):
     # ------------------------------------------------------------------
 
     def _handle_doc_relations_get(self) -> None:
+        # Thin adapter over the doc_relations service (audit P0-1 / A-01). Read —
+        # no write-lock (matches the original). The query string is transport, so
+        # the adapter extracts doc_id; the service validates it.
+        from multicorpus_engine.services.doc_relations_service import get_doc_relations
+        from multicorpus_engine.services.errors import ValidationError
         qs = parse_qs(urlparse(self.path).query)
-        doc_id_str = (qs.get("doc_id") or [None])[0]
-        if doc_id_str is None:
-            self._send_error("doc_id query param is required", code=ERR_BAD_REQUEST, http_status=400)
-            return
+        doc_id_raw = (qs.get("doc_id") or [None])[0]
         try:
-            doc_id = int(doc_id_str)
-        except ValueError:
-            self._send_error("doc_id must be an integer", code=ERR_BAD_REQUEST, http_status=400)
+            data = get_doc_relations(self._conn(), doc_id_raw)
+        except ValidationError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-        rows = self._conn().execute(
-            "SELECT id, doc_id, relation_type, target_doc_id, note, created_at FROM doc_relations WHERE doc_id = ? ORDER BY id",
-            (doc_id,),
-        ).fetchall()
-        relations = [
-            {"id": r[0], "doc_id": r[1], "relation_type": r[2], "target_doc_id": r[3], "note": r[4], "created_at": r[5]}
-            for r in rows
-        ]
-        self._send_json(success_payload({"doc_id": doc_id, "relations": relations, "count": len(relations)}))
+        self._send_json(success_payload(data))
 
     def _handle_doc_relations_all(self) -> None:
-        """GET /doc_relations/all — return every doc_relation row in the corpus.
-
-        Used by the frontend to build the hierarchy view of documents without
-        issuing one request per document.
-        """
-        rows = self._conn().execute(
-            "SELECT id, doc_id, relation_type, target_doc_id, note, created_at"
-            " FROM doc_relations ORDER BY doc_id, id"
-        ).fetchall()
-        relations = [
-            {"id": r[0], "doc_id": r[1], "relation_type": r[2], "target_doc_id": r[3], "note": r[4], "created_at": r[5]}
-            for r in rows
-        ]
-        self._send_json(success_payload({"relations": relations, "count": len(relations)}))
+        # GET /doc_relations/all — every relation in the corpus (frontend hierarchy
+        # view). Read — no write-lock.
+        from multicorpus_engine.services.doc_relations_service import list_all_doc_relations
+        self._send_json(success_payload(list_all_doc_relations(self._conn())))
 
     def _handle_families(self) -> None:
         """GET /families — list all document families (parent + children + completion stats).
@@ -6783,34 +6767,16 @@ class _CorpusHandler(BaseHTTPRequestHandler):
         self._send_json(success_payload({"updated": total_updated}))
 
     def _handle_doc_relations_set(self, body: dict) -> None:
-        doc_id = body.get("doc_id")
-        relation_type = body.get("relation_type")
-        target_doc_id = body.get("target_doc_id")
-        if doc_id is None or not relation_type or target_doc_id is None:
-            self._send_error("doc_id, relation_type, and target_doc_id are required", code=ERR_BAD_REQUEST, http_status=400)
+        # Thin adapter over the doc_relations service (write — owns the lock).
+        from multicorpus_engine.services.doc_relations_service import set_doc_relation
+        from multicorpus_engine.services.errors import ValidationError
+        try:
+            with self._lock():
+                data = set_doc_relation(self._conn(), body)
+        except ValidationError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-        note = body.get("note")
-        with self._lock():
-            existing = self._conn().execute(
-                "SELECT id FROM doc_relations WHERE doc_id = ? AND relation_type = ? AND target_doc_id = ?",
-                (doc_id, relation_type, target_doc_id),
-            ).fetchone()
-            if existing:
-                self._conn().execute(
-                    "UPDATE doc_relations SET note = ? WHERE id = ?",
-                    (note, existing[0]),
-                )
-                rel_id = existing[0]
-                action = "updated"
-            else:
-                cur = self._conn().execute(
-                    "INSERT INTO doc_relations (doc_id, relation_type, target_doc_id, note, created_at) VALUES (?, ?, ?, ?, datetime('now'))",
-                    (doc_id, relation_type, target_doc_id, note),
-                )
-                rel_id = cur.lastrowid
-                action = "created"
-            self._conn().commit()
-        self._send_json(success_payload({"action": action, "id": rel_id, "doc_id": doc_id, "relation_type": relation_type, "target_doc_id": target_doc_id}))
+        self._send_json(success_payload(data))
 
     def _handle_documents_delete(self, body: dict) -> None:
         """POST /documents/delete — supprime un ou plusieurs documents et toutes leurs données liées."""
@@ -6906,14 +6872,16 @@ class _CorpusHandler(BaseHTTPRequestHandler):
         self._send_json(success_payload({"deleted": deleted, "doc_ids": doc_ids}))
 
     def _handle_doc_relations_delete(self, body: dict) -> None:
-        rel_id = body.get("id")
-        if rel_id is None:
-            self._send_error("id is required", code=ERR_BAD_REQUEST, http_status=400)
+        # Thin adapter over the doc_relations service (write — owns the lock).
+        from multicorpus_engine.services.doc_relations_service import delete_doc_relation
+        from multicorpus_engine.services.errors import ValidationError
+        try:
+            with self._lock():
+                data = delete_doc_relation(self._conn(), body)
+        except ValidationError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-        with self._lock():
-            cur = self._conn().execute("DELETE FROM doc_relations WHERE id = ?", (rel_id,))
-            self._conn().commit()
-        self._send_json(success_payload({"deleted": cur.rowcount}))
+        self._send_json(success_payload(data))
 
     # ------------------------------------------------------------------
     # V0.4B — Exports

--- a/tests/services/test_doc_relations_service.py
+++ b/tests/services/test_doc_relations_service.py
@@ -1,0 +1,111 @@
+"""Direct unit tests for the doc_relations service (audit P0-1 / A-01).
+
+Exercises the extracted doc_relations CRUD without any HTTP server. The sidecar
+HTTP adapters are covered end-to-end by tests/test_sidecar_v04.py (set/get/delete)
+and the binary smoke (/doc_relations/all) in CI.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from multicorpus_engine.services.doc_relations_service import (
+    delete_doc_relation,
+    get_doc_relations,
+    list_all_doc_relations,
+    set_doc_relation,
+)
+from multicorpus_engine.services.errors import ValidationError
+
+
+def _mk_doc(conn: sqlite3.Connection, title: str = "D") -> int:
+    cur = conn.execute(
+        "INSERT INTO documents (title, language, doc_role, created_at)"
+        " VALUES (?, 'fr', 'standalone', datetime('now'))",
+        (title,),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+# --- set (upsert) ---------------------------------------------------------------
+def test_set_creates_then_updates(db_conn: sqlite3.Connection) -> None:
+    a, b = _mk_doc(db_conn, "A"), _mk_doc(db_conn, "B")
+    r1 = set_doc_relation(
+        db_conn, {"doc_id": a, "relation_type": "translation_of", "target_doc_id": b}
+    )
+    assert r1["action"] == "created"
+    assert r1["doc_id"] == a and r1["relation_type"] == "translation_of" and r1["target_doc_id"] == b
+    assert isinstance(r1["id"], int)
+
+    # same (doc_id, relation_type, target) -> update note only, same id
+    r2 = set_doc_relation(
+        db_conn,
+        {"doc_id": a, "relation_type": "translation_of", "target_doc_id": b, "note": "hi"},
+    )
+    assert r2["action"] == "updated"
+    assert r2["id"] == r1["id"]
+
+    got = get_doc_relations(db_conn, str(a))
+    assert got["count"] == 1
+    assert got["relations"][0]["note"] == "hi"
+    assert got["relations"][0]["id"] == r1["id"]
+
+
+@pytest.mark.parametrize("body", [
+    {"relation_type": "translation_of", "target_doc_id": 2},  # missing doc_id
+    {"doc_id": 1, "target_doc_id": 2},                        # missing relation_type
+    {"doc_id": 1, "relation_type": "translation_of"},         # missing target_doc_id
+    {"doc_id": 1, "relation_type": "", "target_doc_id": 2},   # empty relation_type
+])
+def test_set_validation(db_conn: sqlite3.Connection, body: dict) -> None:
+    with pytest.raises(ValidationError):
+        set_doc_relation(db_conn, body)
+
+
+# --- get ------------------------------------------------------------------------
+def test_get_returns_relations(db_conn: sqlite3.Connection) -> None:
+    a, b = _mk_doc(db_conn, "A"), _mk_doc(db_conn, "B")
+    set_doc_relation(db_conn, {"doc_id": a, "relation_type": "translation_of", "target_doc_id": b})
+    out = get_doc_relations(db_conn, str(a))
+    assert out["doc_id"] == a
+    assert out["count"] == 1
+    rel = out["relations"][0]
+    assert set(rel) == {"id", "doc_id", "relation_type", "target_doc_id", "note", "created_at"}
+
+
+def test_get_empty_for_unknown_doc(db_conn: sqlite3.Connection) -> None:
+    assert get_doc_relations(db_conn, "999") == {"doc_id": 999, "relations": [], "count": 0}
+
+
+@pytest.mark.parametrize("raw", [None, "abc", ""])
+def test_get_validation(db_conn: sqlite3.Connection, raw) -> None:
+    with pytest.raises(ValidationError):
+        get_doc_relations(db_conn, raw)
+
+
+# --- list all -------------------------------------------------------------------
+def test_list_all(db_conn: sqlite3.Connection) -> None:
+    a, b, c = _mk_doc(db_conn, "A"), _mk_doc(db_conn, "B"), _mk_doc(db_conn, "C")
+    set_doc_relation(db_conn, {"doc_id": a, "relation_type": "translation_of", "target_doc_id": b})
+    set_doc_relation(db_conn, {"doc_id": a, "relation_type": "excerpt_of", "target_doc_id": c})
+    out = list_all_doc_relations(db_conn)
+    assert out["count"] == 2
+    assert {r["relation_type"] for r in out["relations"]} == {"translation_of", "excerpt_of"}
+
+
+# --- delete ---------------------------------------------------------------------
+def test_delete(db_conn: sqlite3.Connection) -> None:
+    a, b = _mk_doc(db_conn, "A"), _mk_doc(db_conn, "B")
+    r = set_doc_relation(db_conn, {"doc_id": a, "relation_type": "translation_of", "target_doc_id": b})
+    assert delete_doc_relation(db_conn, {"id": r["id"]}) == {"deleted": 1}
+    assert get_doc_relations(db_conn, str(a))["count"] == 0
+    # deleting again is a no-op (0 rows)
+    assert delete_doc_relation(db_conn, {"id": r["id"]}) == {"deleted": 0}
+
+
+def test_delete_validation(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(ValidationError):
+        delete_doc_relation(db_conn, {})


### PR DESCRIPTION
## A-01 — service-layer extraction, tranche 3 (after `import`, `conventions`)

The 4 `_handle_doc_relations_*` handlers (the translation_of / excerpt_of family links) become **thin adapters**; validation + SQL move to `services/doc_relations_service.py` (`get_doc_relations` / `list_all_doc_relations` / `set_doc_relation` / `delete_doc_relation`).

### Byte-identical preservation
- These endpoints return **`BAD_REQUEST`** for bad input → adapter maps `ValidationError → ERR_BAD_REQUEST`.
- **Reads (`get` / `all`) take NO write-lock**, exactly like the originals; only the writes (`set` / `delete`) hold the lock.
- The **query-string parse stays in the adapter** (transport); the service validates the `doc_id` value (required / integer).
- `set` still upserts on `(doc_id, relation_type, target_doc_id)` returning `action: created|updated`; `delete` returns `{deleted: rowcount}`.

### Protocol applied (the one we agreed on)
- DB-pure domain ✓
- HTTP coverage ✓ — `tests/test_sidecar_v04.py` already exercises `set`/`get`/`delete` over HTTP; the binary smoke gains a **`/doc_relations/all`** check so the frozen binary exercises this service's lazy import.
- Byte-identical + contract freeze.
- Local service tests + adapter CI.

### Tests
- `tests/services/test_doc_relations_service.py` (13 tests, local via `db_conn`).
- 500 non-sidecar tests pass; ruff `src tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)