### PR TITLE
refactor(P0-1/A-01): extract documents CRUD into a service

### DIFF
--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -41,7 +41,7 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 
 | ID | Sév | Prio | Statut | Constat (résumé) |
 |----|-----|------|--------|------------------|
-| A-01 | 🔴 | P0-1 | 🟦 partiel | `sidecar.py` monolithe. Couche `services/` : `import_service` (#46) + `conventions_service` (#50, +`ConflictError`) + `doc_relations_service` (CRUD relations de famille). Handlers→adapters fins (lock pour les writes, map erreurs, envelope ; réponses byte-identiques). Filet : smoke-run binaire en CI (#51) frappe un GET par couche service. Domaines restants : align/segment/curate/export/documents… |
+| A-01 | 🔴 | P0-1 | 🟦 partiel | `sidecar.py` monolithe. Couche `services/` : `import` (#46) + `conventions` (#50, +`ConflictError`) + `doc_relations` (#52) + `documents` (CRUD métadonnées/workflow, +`BadRequestError`, split télémétrie). Handlers→adapters fins (lock pour writes, map erreurs typées→codes, envelope ; réponses byte-identiques). Couplé laissé en adapter (assumé) : backfill schéma `_ensure_*`, emit télémétrie `doc_deleted`. Filet : smoke-run binaire en CI (#51) frappe un GET par couche service. Domaines restants : align/segment/curate/export… |
 | A-03 | 🟠 | P0-1 | ⬜ ouvert | 66 blocs de validation manuelle (pas de validateur de schéma) |
 | A-04 | 🟡 | P2-13 | ⬜ ouvert | Attributs dynamiques non typés sur `HTTPServer` |
 | Q-02 | 🟠 | P0-1 | ⬜ ouvert | Fonctions géantes ; `_build_hits` vs `_build_hits_regex` (~70 l. dupliquées) |

--- a/scripts/smoke_sidecar.py
+++ b/scripts/smoke_sidecar.py
@@ -32,6 +32,7 @@ from pathlib import Path
 CHECKS: list[tuple[str, str]] = [
     ("/conventions", "conventions"),       # conventions_service
     ("/doc_relations/all", "relations"),   # doc_relations_service
+    ("/documents", "documents"),           # documents_service
 ]
 
 

--- a/src/multicorpus_engine/services/documents_service.py
+++ b/src/multicorpus_engine/services/documents_service.py
@@ -1,0 +1,258 @@
+"""Documents domain service — audit P0-1 / A-01.
+
+CRUD over the ``documents`` table (metadata + workflow status), extracted verbatim
+from the sidecar ``_handle_documents*`` handlers. Pure w.r.t. transport: each
+function takes a connection + request inputs, mutates the DB, returns response
+*data*. The sidecar adapter owns the write-lock (writes), the HTTP envelope, the
+schema backfill (``_ensure_*`` — they manage schema + take the lock) and the
+``doc_deleted`` telemetry emit (server-coupled). Error mapping is per-type:
+``BadRequestError`` -> ERR_BAD_REQUEST, ``ValidationError`` -> ERR_VALIDATION,
+``NotFoundError`` -> ERR_NOT_FOUND — exactly the codes the handlers used.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from ..indexer import stale_doc_ids
+from ..runs import utcnow_iso
+from .errors import BadRequestError, NotFoundError, ValidationError
+
+DOC_WORKFLOW_STATUSES = {"draft", "review", "validated"}
+
+# Columns a client may set via update / bulk_update.
+_UPDATABLE = {
+    "title", "language", "doc_role", "resource_type",
+    "workflow_status", "validated_run_id",
+    "author_lastname", "author_firstname", "doc_date",
+    "translator_lastname", "translator_firstname",
+    "work_title", "pub_place", "publisher",
+}
+
+_NO_FIELDS_MSG = (
+    "No updatable fields provided "
+    "(allowed: title, language, doc_role, resource_type, workflow_status, validated_run_id, "
+    "author_lastname, author_firstname, doc_date, translator_lastname, translator_firstname, "
+    "work_title, pub_place, publisher)"
+)
+
+_LIST_SQL = """
+    SELECT d.doc_id, d.title, d.language, d.doc_role, d.resource_type,
+           d.workflow_status, d.validated_at, d.validated_run_id,
+           d.source_path, d.source_hash,
+           COALESCE(uc.unit_count, 0) AS unit_count,
+           COALESCE(tc.token_count, 0) AS token_count,
+           CASE WHEN COALESCE(tc.token_count, 0) > 0 THEN 'annotated' ELSE 'missing' END AS annotation_status,
+           d.author_lastname, d.author_firstname, d.doc_date,
+           d.text_start_n,
+           d.translator_lastname, d.translator_firstname,
+           d.work_title, d.pub_place, d.publisher
+    FROM documents d
+    LEFT JOIN (
+        SELECT doc_id, COUNT(*) AS unit_count
+        FROM units
+        WHERE unit_type = 'line'
+        GROUP BY doc_id
+    ) uc ON uc.doc_id = d.doc_id
+    LEFT JOIN (
+        SELECT u.doc_id, COUNT(t.token_id) AS token_count
+        FROM units u
+        JOIN tokens t ON t.unit_id = u.unit_id
+        GROUP BY u.doc_id
+    ) tc ON tc.doc_id = d.doc_id
+    ORDER BY d.doc_id
+"""
+
+_UPDATED_DOC_SQL = """
+    SELECT doc_id, title, language, doc_role, resource_type,
+           workflow_status, validated_at, validated_run_id,
+           author_lastname, author_firstname, doc_date,
+           translator_lastname, translator_firstname,
+           work_title, pub_place, publisher
+    FROM documents
+    WHERE doc_id = ?
+"""
+
+
+def list_documents(conn: sqlite3.Connection) -> dict[str, Any]:
+    """List every document with derived counts + FTS staleness (GET /documents).
+
+    The caller must run the schema backfill (``_ensure_document_workflow_columns`` /
+    ``_ensure_tokens_table``) first; those manage schema and hold the lock.
+    """
+    rows = conn.execute(_LIST_SQL).fetchall()
+    stale_ids = stale_doc_ids(conn)  # derived, no persisted flag
+    documents = [
+        {
+            "doc_id": r[0], "title": r[1], "language": r[2], "doc_role": r[3],
+            "resource_type": r[4], "workflow_status": r[5], "validated_at": r[6],
+            "validated_run_id": r[7], "source_path": r[8], "source_hash": r[9],
+            "unit_count": r[10], "token_count": r[11], "annotation_status": r[12],
+            "author_lastname": r[13], "author_firstname": r[14], "doc_date": r[15],
+            "text_start_n": r[16], "translator_lastname": r[17],
+            "translator_firstname": r[18], "work_title": r[19], "pub_place": r[20],
+            "publisher": r[21], "fts_stale": r[0] in stale_ids,
+        }
+        for r in rows
+    ]
+    return {"documents": documents, "count": len(documents)}
+
+
+def _coerce_workflow_fields(fields: dict) -> None:
+    """Validate + normalise workflow_status / validated_run_id in-place (shared by
+    update and bulk_update). Raises ValidationError on any rule violation."""
+    workflow_status = fields.get("workflow_status")
+    if workflow_status is not None:
+        if not isinstance(workflow_status, str) or workflow_status not in DOC_WORKFLOW_STATUSES:
+            raise ValidationError(
+                "workflow_status must be one of: draft, review, validated",
+                details={"supported_values": sorted(DOC_WORKFLOW_STATUSES)},
+            )
+        if workflow_status == "validated":
+            fields.setdefault("validated_at", utcnow_iso())
+            if "validated_run_id" in fields and fields["validated_run_id"] is not None:
+                if not isinstance(fields["validated_run_id"], str) or not fields["validated_run_id"].strip():
+                    raise ValidationError("validated_run_id must be a non-empty string or null")
+                fields["validated_run_id"] = fields["validated_run_id"].strip()
+        else:
+            # Leaving validated state clears validation metadata.
+            fields["validated_at"] = None
+            fields["validated_run_id"] = None
+    elif "validated_run_id" in fields:
+        raise ValidationError("validated_run_id can only be set when workflow_status='validated'")
+
+
+def update_document(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """Update one document's metadata (POST /documents/update).
+
+    Raises BadRequestError (no doc_id / no fields), ValidationError (workflow rules)
+    or NotFoundError (unknown doc_id).
+    """
+    doc_id = body.get("doc_id")
+    if doc_id is None:
+        raise BadRequestError("doc_id is required")
+    updates = {k: v for k, v in body.items() if k in _UPDATABLE}
+    if not updates:
+        raise BadRequestError(_NO_FIELDS_MSG)
+
+    _coerce_workflow_fields(updates)
+
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    params = list(updates.values()) + [doc_id]
+    cur = conn.execute(f"UPDATE documents SET {set_clause} WHERE doc_id = ?", params)
+    conn.commit()
+    if cur.rowcount == 0:
+        raise NotFoundError(f"Document doc_id={doc_id} not found")
+
+    row = conn.execute(_UPDATED_DOC_SQL, (doc_id,)).fetchone()
+    doc = {
+        "doc_id": row[0], "title": row[1], "language": row[2], "doc_role": row[3],
+        "resource_type": row[4], "workflow_status": row[5], "validated_at": row[6],
+        "validated_run_id": row[7], "author_lastname": row[8], "author_firstname": row[9],
+        "doc_date": row[10], "translator_lastname": row[11], "translator_firstname": row[12],
+        "work_title": row[13], "pub_place": row[14], "publisher": row[15],
+    }
+    return {"updated": 1, "doc": doc}
+
+
+def bulk_update_documents(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """Update many documents in one transaction (POST /documents/bulk_update).
+
+    Items with no doc_id or no updatable field are skipped. Raises BadRequestError
+    (bad list) or ValidationError (workflow rules). NOTE: a ValidationError raised
+    mid-loop leaves the earlier UPDATEs uncommitted — preserved verbatim from the
+    original handler.
+    """
+    updates_list = body.get("updates")
+    if not isinstance(updates_list, list) or not updates_list:
+        raise BadRequestError("updates must be a non-empty list of {doc_id, ...fields}")
+
+    total_updated = 0
+    for item in updates_list:
+        doc_id = item.get("doc_id")
+        if doc_id is None:
+            continue
+        fields = {k: v for k, v in item.items() if k in _UPDATABLE}
+        if not fields:
+            continue
+        _coerce_workflow_fields(fields)
+        set_clause = ", ".join(f"{k} = ?" for k in fields)
+        params = list(fields.values()) + [doc_id]
+        cur = conn.execute(f"UPDATE documents SET {set_clause} WHERE doc_id = ?", params)
+        total_updated += cur.rowcount
+    conn.commit()
+    return {"updated": total_updated}
+
+
+def delete_documents(conn: sqlite3.Connection, body: dict) -> tuple[dict[str, Any], list[dict]]:
+    """Delete documents + all linked data (POST /documents/delete).
+
+    Returns ``(data, telemetry_entries)`` — the caller (adapter) emits the
+    ``doc_deleted`` telemetry (server-coupled) post-commit. Raises BadRequestError
+    on a bad ``doc_ids`` payload.
+    """
+    doc_ids = body.get("doc_ids")
+    if not isinstance(doc_ids, list) or not doc_ids:
+        raise BadRequestError("doc_ids (non-empty list) is required")
+    if not all(isinstance(d, int) for d in doc_ids):
+        raise BadRequestError("doc_ids must be a list of integers")
+    placeholders = ",".join("?" * len(doc_ids))
+
+    # Telemetry preview: collect had_curation/had_alignment BEFORE delete.
+    telemetry_pre: list[dict] = []
+    try:
+        for did in doc_ids:
+            had_cur = conn.execute(
+                "SELECT 1 FROM curation_apply_history WHERE doc_id = ? LIMIT 1", (did,)
+            ).fetchone() is not None
+            had_align = conn.execute(
+                "SELECT 1 FROM alignment_links WHERE pivot_doc_id = ? OR target_doc_id = ? LIMIT 1",
+                (did, did),
+            ).fetchone() is not None
+            telemetry_pre.append(
+                {"doc_id": did, "had_curation": had_cur, "had_alignment": had_align}
+            )
+    except Exception:  # noqa: BLE001
+        pass  # telemetry must never block the delete
+
+    # 1. Collect unit_ids before deletion (needed for FTS cleanup).
+    unit_ids: list[int] = [
+        row[0] for row in conn.execute(
+            f"SELECT unit_id FROM units WHERE doc_id IN ({placeholders})", doc_ids
+        ).fetchall()
+    ]
+    # 2. alignment_links — pivot_doc_id / target_doc_id directly.
+    conn.execute(
+        f"DELETE FROM alignment_links"
+        f" WHERE pivot_doc_id IN ({placeholders}) OR target_doc_id IN ({placeholders})",
+        doc_ids + doc_ids,
+    )
+    # 3. FTS index — BEFORE units are deleted (rowid = unit_id).
+    if unit_ids:
+        fts_ph = ",".join("?" * len(unit_ids))
+        try:
+            conn.execute(f"DELETE FROM fts_units WHERE rowid IN ({fts_ph})", unit_ids)
+        except Exception:
+            pass  # FTS table may not exist
+    # 4. Units — curation_exceptions cascade automatically (ON DELETE CASCADE).
+    conn.execute(f"DELETE FROM units WHERE doc_id IN ({placeholders})", doc_ids)
+    # 5. Doc relations.
+    conn.execute(
+        f"DELETE FROM doc_relations"
+        f" WHERE doc_id IN ({placeholders}) OR target_doc_id IN ({placeholders})",
+        doc_ids + doc_ids,
+    )
+    # 6. Curation apply history (doc_id without FK — orphaned rows).
+    try:
+        conn.execute(
+            f"DELETE FROM curation_apply_history WHERE doc_id IN ({placeholders})", doc_ids
+        )
+    except Exception:
+        pass  # table may not exist in older DBs
+    # 7. Documents.
+    cur = conn.execute(f"DELETE FROM documents WHERE doc_id IN ({placeholders})", doc_ids)
+    deleted = cur.rowcount
+    conn.commit()
+
+    return {"deleted": deleted, "doc_ids": doc_ids}, telemetry_pre

--- a/src/multicorpus_engine/services/errors.py
+++ b/src/multicorpus_engine/services/errors.py
@@ -34,6 +34,15 @@ class ValidationError(ServiceError):
     http_status = 400
 
 
+class BadRequestError(ServiceError):
+    """Malformed request shape (missing/blank required field, wrong type). Maps to
+    ERR_BAD_REQUEST / 400. Distinct from ValidationError so an endpoint that
+    historically returned both BAD_REQUEST (shape) and VALIDATION_ERROR (domain
+    rules) stays byte-identical."""
+
+    http_status = 400
+
+
 class NotFoundError(ServiceError):
     """A referenced entity does not exist. Maps to ERR_NOT_FOUND / 404."""
 

--- a/src/multicorpus_engine/sidecar.py
+++ b/src/multicorpus_engine/sidecar.py
@@ -62,8 +62,6 @@ from . import __version__ as ENGINE_VERSION
 
 logger = logging.getLogger(__name__)
 
-_DOC_WORKFLOW_STATUSES = {"draft", "review", "validated"}
-
 
 def _int_param(value: object, default: int) -> int:
     """Coerce *value* to int, returning *default* on TypeError/ValueError.
@@ -5334,68 +5332,12 @@ class _CorpusHandler(BaseHTTPRequestHandler):
         self._send_json(success_payload({"units": units, "count": len(units), "doc_id": doc_id}))
 
     def _handle_documents(self) -> None:
+        # Thin adapter over the documents service (audit P0-1 / A-01). Read — no
+        # write-lock. Schema backfill stays here (manages schema + takes the lock).
+        from multicorpus_engine.services.documents_service import list_documents
         self._ensure_document_workflow_columns()
         self._ensure_tokens_table()
-        rows = self._conn().execute(
-            """
-            SELECT d.doc_id, d.title, d.language, d.doc_role, d.resource_type,
-                   d.workflow_status, d.validated_at, d.validated_run_id,
-                   d.source_path, d.source_hash,
-                   COALESCE(uc.unit_count, 0) AS unit_count,
-                   COALESCE(tc.token_count, 0) AS token_count,
-                   CASE WHEN COALESCE(tc.token_count, 0) > 0 THEN 'annotated' ELSE 'missing' END AS annotation_status,
-                   d.author_lastname, d.author_firstname, d.doc_date,
-                   d.text_start_n,
-                   d.translator_lastname, d.translator_firstname,
-                   d.work_title, d.pub_place, d.publisher
-            FROM documents d
-            LEFT JOIN (
-                SELECT doc_id, COUNT(*) AS unit_count
-                FROM units
-                WHERE unit_type = 'line'
-                GROUP BY doc_id
-            ) uc ON uc.doc_id = d.doc_id
-            LEFT JOIN (
-                SELECT u.doc_id, COUNT(t.token_id) AS token_count
-                FROM units u
-                JOIN tokens t ON t.unit_id = u.unit_id
-                GROUP BY u.doc_id
-            ) tc ON tc.doc_id = d.doc_id
-            ORDER BY d.doc_id
-            """
-        ).fetchall()
-        # FTS staleness dérivée (pas de flag persisté) — cf. indexer.stale_doc_ids.
-        from multicorpus_engine.indexer import stale_doc_ids
-        stale_ids = stale_doc_ids(self._conn())
-        documents = [
-            {
-                "doc_id": r[0],
-                "title": r[1],
-                "language": r[2],
-                "doc_role": r[3],
-                "resource_type": r[4],
-                "workflow_status": r[5],
-                "validated_at": r[6],
-                "validated_run_id": r[7],
-                "source_path": r[8],
-                "source_hash": r[9],
-                "unit_count": r[10],
-                "token_count": r[11],
-                "annotation_status": r[12],
-                "author_lastname": r[13],
-                "author_firstname": r[14],
-                "doc_date": r[15],
-                "text_start_n": r[16],
-                "translator_lastname": r[17],
-                "translator_firstname": r[18],
-                "work_title": r[19],
-                "pub_place": r[20],
-                "publisher": r[21],
-                "fts_stale": r[0] in stale_ids,
-            }
-            for r in rows
-        ]
-        self._send_json(success_payload({"documents": documents, "count": len(documents)}))
+        self._send_json(success_payload(list_documents(self._conn())))
 
     def _ensure_document_workflow_columns(self) -> None:
         """Backfill optional document columns when running against legacy DB schemas."""
@@ -6608,163 +6550,42 @@ class _CorpusHandler(BaseHTTPRequestHandler):
         self._send_json(success_payload({"families": families, "count": len(families)}))
 
     def _handle_documents_update(self, body: dict) -> None:
+        # Thin adapter over the documents service. Per-type error mapping keeps the
+        # endpoint's mixed wire codes (BAD_REQUEST shape vs VALIDATION_ERROR rules).
+        from multicorpus_engine.services.documents_service import update_document
+        from multicorpus_engine.services.errors import (
+            BadRequestError, NotFoundError, ValidationError,
+        )
         self._ensure_document_workflow_columns()
-        doc_id = body.get("doc_id")
-        if doc_id is None:
-            self._send_error("doc_id is required", code=ERR_BAD_REQUEST, http_status=400)
+        try:
+            with self._lock():
+                data = update_document(self._conn(), body)
+        except BadRequestError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-        allowed = {
-            "title", "language", "doc_role", "resource_type",
-            "workflow_status", "validated_run_id",
-            "author_lastname", "author_firstname", "doc_date",
-            "translator_lastname", "translator_firstname",
-            "work_title", "pub_place", "publisher",
-        }
-        updates = {k: v for k, v in body.items() if k in allowed}
-        if not updates:
-            self._send_error(
-                "No updatable fields provided "
-                "(allowed: title, language, doc_role, resource_type, workflow_status, validated_run_id, "
-                "author_lastname, author_firstname, doc_date, translator_lastname, translator_firstname, "
-                "work_title, pub_place, publisher)",
-                code=ERR_BAD_REQUEST,
-                http_status=400,
-            )
+        except ValidationError as exc:
+            self._send_error(exc.message, code=ERR_VALIDATION, http_status=exc.http_status, details=exc.details)
             return
-
-        workflow_status = updates.get("workflow_status")
-        if workflow_status is not None:
-            if not isinstance(workflow_status, str) or workflow_status not in _DOC_WORKFLOW_STATUSES:
-                self._send_error(
-                    "workflow_status must be one of: draft, review, validated",
-                    code=ERR_VALIDATION,
-                    http_status=400,
-                    details={"supported_values": sorted(_DOC_WORKFLOW_STATUSES)},
-                )
-                return
-            if workflow_status == "validated":
-                updates.setdefault("validated_at", utcnow_iso())
-                if "validated_run_id" in updates and updates["validated_run_id"] is not None:
-                    if not isinstance(updates["validated_run_id"], str) or not updates["validated_run_id"].strip():
-                        self._send_error(
-                            "validated_run_id must be a non-empty string or null",
-                            code=ERR_VALIDATION,
-                            http_status=400,
-                        )
-                        return
-                    updates["validated_run_id"] = updates["validated_run_id"].strip()
-            else:
-                # Leaving validated state clears validation metadata.
-                updates["validated_at"] = None
-                updates["validated_run_id"] = None
-        elif "validated_run_id" in updates:
-            self._send_error(
-                "validated_run_id can only be set when workflow_status='validated'",
-                code=ERR_VALIDATION,
-                http_status=400,
-            )
+        except NotFoundError as exc:
+            self._send_error(exc.message, code=ERR_NOT_FOUND, http_status=exc.http_status)
             return
-
-        set_clause = ", ".join(f"{k} = ?" for k in updates)
-        params = list(updates.values()) + [doc_id]
-        with self._lock():
-            cur = self._conn().execute(f"UPDATE documents SET {set_clause} WHERE doc_id = ?", params)
-            self._conn().commit()
-            rows_updated = cur.rowcount
-        if rows_updated == 0:
-            self._send_error(f"Document doc_id={doc_id} not found", code=ERR_NOT_FOUND, http_status=404)
-            return
-        row = self._conn().execute(
-            """
-            SELECT doc_id, title, language, doc_role, resource_type,
-                   workflow_status, validated_at, validated_run_id,
-                   author_lastname, author_firstname, doc_date,
-                   translator_lastname, translator_firstname,
-                   work_title, pub_place, publisher
-            FROM documents
-            WHERE doc_id = ?
-            """,
-            (doc_id,),
-        ).fetchone()
-        doc = {
-            "doc_id": row[0],
-            "title": row[1],
-            "language": row[2],
-            "doc_role": row[3],
-            "resource_type": row[4],
-            "workflow_status": row[5],
-            "validated_at": row[6],
-            "validated_run_id": row[7],
-            "author_lastname": row[8],
-            "author_firstname": row[9],
-            "doc_date": row[10],
-            "translator_lastname": row[11],
-            "translator_firstname": row[12],
-            "work_title": row[13],
-            "pub_place": row[14],
-            "publisher": row[15],
-        }
-        self._send_json(success_payload({"updated": 1, "doc": doc}))
+        self._send_json(success_payload(data))
 
     def _handle_documents_bulk_update(self, body: dict) -> None:
+        # Thin adapter over the documents service.
+        from multicorpus_engine.services.documents_service import bulk_update_documents
+        from multicorpus_engine.services.errors import BadRequestError, ValidationError
         self._ensure_document_workflow_columns()
-        updates_list = body.get("updates")
-        if not isinstance(updates_list, list) or not updates_list:
-            self._send_error("updates must be a non-empty list of {doc_id, ...fields}", code=ERR_BAD_REQUEST, http_status=400)
+        try:
+            with self._lock():
+                data = bulk_update_documents(self._conn(), body)
+        except BadRequestError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-        allowed = {
-            "title", "language", "doc_role", "resource_type",
-            "workflow_status", "validated_run_id",
-            "author_lastname", "author_firstname", "doc_date",
-            "translator_lastname", "translator_firstname",
-            "work_title", "pub_place", "publisher",
-        }
-        total_updated = 0
-        with self._lock():
-            for item in updates_list:
-                doc_id = item.get("doc_id")
-                if doc_id is None:
-                    continue
-                fields = {k: v for k, v in item.items() if k in allowed}
-                if not fields:
-                    continue
-                workflow_status = fields.get("workflow_status")
-                if workflow_status is not None:
-                    if not isinstance(workflow_status, str) or workflow_status not in _DOC_WORKFLOW_STATUSES:
-                        self._send_error(
-                            "workflow_status must be one of: draft, review, validated",
-                            code=ERR_VALIDATION,
-                            http_status=400,
-                            details={"supported_values": sorted(_DOC_WORKFLOW_STATUSES)},
-                        )
-                        return
-                    if workflow_status == "validated":
-                        fields.setdefault("validated_at", utcnow_iso())
-                        if "validated_run_id" in fields and fields["validated_run_id"] is not None:
-                            if not isinstance(fields["validated_run_id"], str) or not fields["validated_run_id"].strip():
-                                self._send_error(
-                                    "validated_run_id must be a non-empty string or null",
-                                    code=ERR_VALIDATION,
-                                    http_status=400,
-                                )
-                                return
-                            fields["validated_run_id"] = fields["validated_run_id"].strip()
-                    else:
-                        fields["validated_at"] = None
-                        fields["validated_run_id"] = None
-                elif "validated_run_id" in fields:
-                    self._send_error(
-                        "validated_run_id can only be set when workflow_status='validated'",
-                        code=ERR_VALIDATION,
-                        http_status=400,
-                    )
-                    return
-                set_clause = ", ".join(f"{k} = ?" for k in fields)
-                params = list(fields.values()) + [doc_id]
-                cur = self._conn().execute(f"UPDATE documents SET {set_clause} WHERE doc_id = ?", params)
-                total_updated += cur.rowcount
-            self._conn().commit()
-        self._send_json(success_payload({"updated": total_updated}))
+        except ValidationError as exc:
+            self._send_error(exc.message, code=ERR_VALIDATION, http_status=exc.http_status, details=exc.details)
+            return
+        self._send_json(success_payload(data))
 
     def _handle_doc_relations_set(self, body: dict) -> None:
         # Thin adapter over the doc_relations service (write — owns the lock).
@@ -6779,97 +6600,27 @@ class _CorpusHandler(BaseHTTPRequestHandler):
         self._send_json(success_payload(data))
 
     def _handle_documents_delete(self, body: dict) -> None:
-        """POST /documents/delete — supprime un ou plusieurs documents et toutes leurs données liées."""
-        doc_ids = body.get("doc_ids")
-        if not isinstance(doc_ids, list) or not doc_ids:
-            self._send_error("doc_ids (non-empty list) is required", code=ERR_BAD_REQUEST, http_status=400)
-            return
-        if not all(isinstance(d, int) for d in doc_ids):
-            self._send_error("doc_ids must be a list of integers", code=ERR_BAD_REQUEST, http_status=400)
-            return
-        placeholders = ",".join("?" * len(doc_ids))
-
-        # Telemetry preview: collect had_curation/had_alignment BEFORE delete
-        # for each doc_id — emitted after the delete commits (one event per doc).
-        # NOTE: choix par défaut — un event par doc supprimé. Si le batch est
-        # large (rare), ça génère N lignes NDJSON. Acceptable pour le volume
-        # d'usage actuel.
-        _telemetry_pre: list[dict] = []
+        # Thin adapter over the documents service. The cascade is DB-pure (service);
+        # the doc_deleted telemetry emit (needs self.server.db_path) stays here.
+        from multicorpus_engine.services.documents_service import delete_documents
+        from multicorpus_engine.services.errors import BadRequestError
         try:
-            _conn_pre = self._conn()
-            for did in doc_ids:
-                had_cur = _conn_pre.execute(
-                    "SELECT 1 FROM curation_apply_history WHERE doc_id = ? LIMIT 1",
-                    (did,),
-                ).fetchone() is not None
-                had_align = _conn_pre.execute(
-                    "SELECT 1 FROM alignment_links WHERE pivot_doc_id = ? OR target_doc_id = ? LIMIT 1",
-                    (did, did),
-                ).fetchone() is not None
-                _telemetry_pre.append({
-                    "doc_id": did, "had_curation": had_cur, "had_alignment": had_align,
-                })
-        except Exception:  # noqa: BLE001
-            pass  # telemetry must never block the delete
-        deleted = 0
-        with self._lock():
-            conn = self._conn()
-
-            # 1. Collect unit_ids before deletion (needed for FTS cleanup)
-            unit_ids: list[int] = [
-                row[0] for row in conn.execute(
-                    f"SELECT unit_id FROM units WHERE doc_id IN ({placeholders})", doc_ids
-                ).fetchall()
-            ]
-
-            # 2. alignment_links — uses pivot_doc_id / target_doc_id directly
-            conn.execute(
-                f"DELETE FROM alignment_links"
-                f" WHERE pivot_doc_id IN ({placeholders}) OR target_doc_id IN ({placeholders})",
-                doc_ids + doc_ids,
-            )
-
-            # 3. FTS index — must happen BEFORE units are deleted (rowid = unit_id)
-            if unit_ids:
-                fts_ph = ",".join("?" * len(unit_ids))
-                try:
-                    conn.execute(f"DELETE FROM fts_units WHERE rowid IN ({fts_ph})", unit_ids)
-                except Exception:
-                    pass  # FTS table may not exist
-
-            # 4. Units — curation_exceptions cascade automatically (ON DELETE CASCADE)
-            conn.execute(f"DELETE FROM units WHERE doc_id IN ({placeholders})", doc_ids)
-
-            # 5. Doc relations
-            conn.execute(
-                f"DELETE FROM doc_relations"
-                f" WHERE doc_id IN ({placeholders}) OR target_doc_id IN ({placeholders})",
-                doc_ids + doc_ids,
-            )
-
-            # 6. Curation apply history (doc_id without FK — orphaned history rows)
-            try:
-                conn.execute(
-                    f"DELETE FROM curation_apply_history WHERE doc_id IN ({placeholders})",
-                    doc_ids,
-                )
-            except Exception:
-                pass  # table may not exist in older DBs
-
-            # 8. Documents
-            cur = conn.execute(f"DELETE FROM documents WHERE doc_id IN ({placeholders})", doc_ids)
-            deleted = cur.rowcount
-            conn.commit()
-        # Telemetry : emit one doc_deleted event per doc, post-commit
+            with self._lock():
+                data, telemetry_entries = delete_documents(self._conn(), body)
+        except BadRequestError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
+            return
+        # Telemetry: one doc_deleted event per doc, post-commit. Server-coupled
+        # (self.server.db_path) so it stays in the adapter; never blocks the delete.
         try:
             from multicorpus_engine.telemetry import emit_event
             _db = getattr(self.server, "db_path", None)
             if isinstance(_db, str) and _db:
-                for entry in _telemetry_pre:
+                for entry in telemetry_entries:
                     emit_event(_db, "doc_deleted", **entry)
         except Exception:  # noqa: BLE001
             pass
-        self._send_json(success_payload({"deleted": deleted, "doc_ids": doc_ids}))
+        self._send_json(success_payload(data))
 
     def _handle_doc_relations_delete(self, body: dict) -> None:
         # Thin adapter over the doc_relations service (write — owns the lock).

--- a/tests/services/test_documents_service.py
+++ b/tests/services/test_documents_service.py
@@ -1,0 +1,160 @@
+"""Direct unit tests for the documents service (audit P0-1 / A-01).
+
+Exercises the extracted documents CRUD without any HTTP server. The migrated
+schema already has the workflow columns + tokens table, so list_documents works
+without the adapter's legacy backfill. HTTP adapters stay covered by
+tests/test_sidecar_v04.py / test_sidecar_api_contract.py + the binary smoke
+(GET /documents).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from multicorpus_engine.services.documents_service import (
+    bulk_update_documents,
+    delete_documents,
+    list_documents,
+    update_document,
+)
+from multicorpus_engine.services.errors import (
+    BadRequestError,
+    NotFoundError,
+    ValidationError,
+)
+
+
+def _mk_doc(conn: sqlite3.Connection, title: str = "D") -> int:
+    cur = conn.execute(
+        "INSERT INTO documents (title, language, doc_role, created_at)"
+        " VALUES (?, 'fr', 'standalone', datetime('now'))",
+        (title,),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+# --- list -----------------------------------------------------------------------
+def test_list_empty(db_conn: sqlite3.Connection) -> None:
+    assert list_documents(db_conn) == {"documents": [], "count": 0}
+
+
+def test_list_shapes_each_row(db_conn: sqlite3.Connection) -> None:
+    _mk_doc(db_conn, "Doc A")
+    out = list_documents(db_conn)
+    assert out["count"] == 1
+    doc = out["documents"][0]
+    assert doc["title"] == "Doc A"
+    assert doc["workflow_status"] == "draft"          # column default
+    assert doc["unit_count"] == 0 and doc["token_count"] == 0
+    assert doc["annotation_status"] == "missing"
+    assert doc["fts_stale"] is False
+    for key in ("doc_id", "source_path", "source_hash", "text_start_n", "publisher"):
+        assert key in doc
+
+
+# --- update ---------------------------------------------------------------------
+def test_update_title(db_conn: sqlite3.Connection) -> None:
+    d = _mk_doc(db_conn, "Old")
+    out = update_document(db_conn, {"doc_id": d, "title": "New"})
+    assert out == {"updated": 1, "doc": out["doc"]}
+    assert out["doc"]["title"] == "New"
+
+
+def test_update_requires_doc_id(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(BadRequestError):
+        update_document(db_conn, {"title": "x"})
+
+
+def test_update_requires_a_field(db_conn: sqlite3.Connection) -> None:
+    d = _mk_doc(db_conn)
+    with pytest.raises(BadRequestError):
+        update_document(db_conn, {"doc_id": d, "not_allowed": 1})
+
+
+def test_update_not_found(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(NotFoundError):
+        update_document(db_conn, {"doc_id": 99999, "title": "x"})
+
+
+def test_update_bad_workflow_status_has_details(db_conn: sqlite3.Connection) -> None:
+    d = _mk_doc(db_conn)
+    with pytest.raises(ValidationError) as ei:
+        update_document(db_conn, {"doc_id": d, "workflow_status": "nope"})
+    assert ei.value.details == {"supported_values": ["draft", "review", "validated"]}
+
+
+def test_update_validated_sets_validated_at(db_conn: sqlite3.Connection) -> None:
+    d = _mk_doc(db_conn)
+    out = update_document(db_conn, {"doc_id": d, "workflow_status": "validated"})
+    assert out["doc"]["workflow_status"] == "validated"
+    assert out["doc"]["validated_at"]  # non-null timestamp set
+
+
+def test_update_leaving_validated_clears_metadata(db_conn: sqlite3.Connection) -> None:
+    d = _mk_doc(db_conn)
+    update_document(db_conn, {"doc_id": d, "workflow_status": "validated", "validated_run_id": "r1"})
+    out = update_document(db_conn, {"doc_id": d, "workflow_status": "draft"})
+    assert out["doc"]["validated_at"] is None
+    assert out["doc"]["validated_run_id"] is None
+
+
+def test_update_validated_run_id_requires_validated(db_conn: sqlite3.Connection) -> None:
+    d = _mk_doc(db_conn)
+    with pytest.raises(ValidationError):
+        update_document(db_conn, {"doc_id": d, "validated_run_id": "r1"})
+
+
+# --- bulk update ----------------------------------------------------------------
+def test_bulk_update(db_conn: sqlite3.Connection) -> None:
+    a, b = _mk_doc(db_conn, "A"), _mk_doc(db_conn, "B")
+    out = bulk_update_documents(db_conn, {"updates": [
+        {"doc_id": a, "title": "A2"},
+        {"doc_id": b, "language": "en"},
+        {"doc_id": None, "title": "skip"},      # skipped (no doc_id)
+        {"doc_id": a, "irrelevant": 1},         # skipped (no updatable field)
+    ]})
+    assert out["updated"] == 2
+
+
+def test_bulk_update_bad_list(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(BadRequestError):
+        bulk_update_documents(db_conn, {"updates": []})
+
+
+def test_bulk_update_bad_workflow_status(db_conn: sqlite3.Connection) -> None:
+    a = _mk_doc(db_conn, "A")
+    with pytest.raises(ValidationError):
+        bulk_update_documents(db_conn, {"updates": [{"doc_id": a, "workflow_status": "bogus"}]})
+
+
+# --- delete ---------------------------------------------------------------------
+def test_delete_removes_doc_units_relations(db_conn: sqlite3.Connection) -> None:
+    a, b = _mk_doc(db_conn, "A"), _mk_doc(db_conn, "B")
+    db_conn.execute(
+        "INSERT INTO units (doc_id, unit_type, n, text_raw, text_norm) VALUES (?, 'line', 1, 'x', 'x')",
+        (a,),
+    )
+    db_conn.execute(
+        "INSERT INTO doc_relations (doc_id, relation_type, target_doc_id, created_at)"
+        " VALUES (?, 'translation_of', ?, datetime('now'))",
+        (a, b),
+    )
+    db_conn.commit()
+
+    data, telemetry = delete_documents(db_conn, {"doc_ids": [a]})
+    assert data == {"deleted": 1, "doc_ids": [a]}
+    assert db_conn.execute("SELECT 1 FROM documents WHERE doc_id=?", (a,)).fetchone() is None
+    assert db_conn.execute("SELECT COUNT(*) FROM units WHERE doc_id=?", (a,)).fetchone()[0] == 0
+    assert db_conn.execute("SELECT COUNT(*) FROM doc_relations WHERE doc_id=?", (a,)).fetchone()[0] == 0
+    # telemetry: one entry per doc, with the expected keys
+    assert telemetry == [{"doc_id": a, "had_curation": False, "had_alignment": False}]
+
+
+def test_delete_bad_payload(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(BadRequestError):
+        delete_documents(db_conn, {"doc_ids": []})
+    with pytest.raises(BadRequestError):
+        delete_documents(db_conn, {"doc_ids": ["not-int"]})


### PR DESCRIPTION
## A-01 — service-layer extraction, tranche 4 (the most nuanced)

The 4 `_handle_documents*` handlers (`list` / `update` / `bulk_update` / `delete`) become **thin adapters**; validation + SQL move to `services/documents_service.py`.

### New vocabulary: `BadRequestError`
These endpoints use **both** `BAD_REQUEST` (request shape: missing doc_id, no fields) **and** `VALIDATION_ERROR` (domain rules: workflow_status, validated_run_id) within a single handler. The service needs two error types to stay byte-identical. Adapter maps `BadRequestError → ERR_BAD_REQUEST`, `ValidationError → ERR_VALIDATION` (+`details`), `NotFoundError → ERR_NOT_FOUND`.

### Server-coupled parts deliberately LEFT in the adapter
Per the agreed protocol ("extract DB-pure, leave coupled"):
- `_ensure_document_workflow_columns` / `_ensure_tokens_table` (schema backfill, hold the lock) — adapter calls them **before** the service.
- the `doc_deleted` **telemetry emit** (needs `self.server.db_path`) — `delete_documents` returns `(data, telemetry_entries)` and the adapter emits post-commit.

### Preserved verbatim
- dynamic UPDATE; bulk loop (invalid items skipped; a `ValidationError` mid-loop leaves earlier UPDATEs uncommitted — documented pre-existing edge case);
- delete cascade order (`alignment_links → fts_units → units → doc_relations → curation_apply_history → documents`);
- `utcnow_iso` format (imported from `runs`, byte-identical to the sidecar's);
- `_DOC_WORKFLOW_STATUSES` moved into the service (removed from sidecar).

### Coverage
- `tests/services/test_documents_service.py` (15 tests, local via `db_conn`): the 3 error codes, workflow transitions (validated set/clear), bulk skip/partial, delete cascade + telemetry shape.
- HTTP adapters stay covered by `test_sidecar_v04.py` / `test_sidecar_api_contract.py`; the binary smoke gains a **`GET /documents`** check.
- 515 non-sidecar tests pass; ruff `src tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)