### PR TITLE
refactor(P0-1/A-01): extract curate CRUD (exceptions + apply_history) into a service

### DIFF
--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -41,7 +41,7 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 
 | ID | Sév | Prio | Statut | Constat (résumé) |
 |----|-----|------|--------|------------------|
-| A-01 | 🔴 | P0-1 | 🟦 partiel | `sidecar.py` monolithe. Couche `services/` : `import` (#46) + `conventions` (#50, +`ConflictError`) + `doc_relations` (#52) + `documents` (CRUD métadonnées/workflow, +`BadRequestError`, split télémétrie). Handlers→adapters fins (lock pour writes, map erreurs typées→codes, envelope ; réponses byte-identiques). Couplé laissé en adapter (assumé) : backfill schéma `_ensure_*`, emit télémétrie `doc_deleted`. Filet : smoke-run binaire en CI (#51) frappe un GET par couche service. Domaines restants : align/segment/curate/export… |
+| A-01 | 🔴 | P0-1 | 🟦 partiel | `sidecar.py` monolithe. Couche `services/` : `import` (#46) + `conventions` (#50) + `doc_relations` (#52) + `documents` (#53, +`BadRequestError`) + `curate`-CRUD (exceptions + apply_history). Handlers→adapters fins (lock writes, map erreurs typées→codes, envelope ; byte-identiques). Couplé laissé en adapter (assumé) : backfill schéma `_ensure_*`, télémétrie `doc_deleted`. Filet : smoke-run binaire en CI (#51) = 1 GET/couche. **Écarté** : `export` (lock incohérent par handler + valeur faible, format déjà dans `exporters/`). Restants : `units`, `query`/`token`/`stats` ; `curate_preview`/`*_export` (couplés/volumineux) et `align`/`segment`/`jobs` (à état/couplés) laissés. |
 | A-03 | 🟠 | P0-1 | ⬜ ouvert | 66 blocs de validation manuelle (pas de validateur de schéma) |
 | A-04 | 🟡 | P2-13 | ⬜ ouvert | Attributs dynamiques non typés sur `HTTPServer` |
 | Q-02 | 🟠 | P0-1 | ⬜ ouvert | Fonctions géantes ; `_build_hits` vs `_build_hits_regex` (~70 l. dupliquées) |

--- a/scripts/smoke_sidecar.py
+++ b/scripts/smoke_sidecar.py
@@ -33,6 +33,7 @@ CHECKS: list[tuple[str, str]] = [
     ("/conventions", "conventions"),       # conventions_service
     ("/doc_relations/all", "relations"),   # doc_relations_service
     ("/documents", "documents"),           # documents_service
+    ("/curate/exceptions", "exceptions"),  # curate_service
 ]
 
 

--- a/src/multicorpus_engine/services/curate_service.py
+++ b/src/multicorpus_engine/services/curate_service.py
@@ -1,0 +1,190 @@
+"""Curation domain service (CRUD subset) — audit P0-1 / A-01.
+
+The curation-exceptions and apply-history CRUD, extracted verbatim from the
+sidecar ``_handle_curate_*`` handlers. Pure w.r.t. transport: each function takes
+a connection + the request body and returns response *data*. The adapter owns the
+write-lock and the HTTP envelope, mapping BadRequestError -> ERR_BAD_REQUEST and
+NotFoundError -> ERR_NOT_FOUND (the codes these endpoints used).
+
+Out of scope for this tranche (kept as handlers): ``curate_preview`` (server-coupled),
+the ``*_export`` handlers (bulky inline formatting + file writes), and ``curate``
+(delegates to curation.py).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from .errors import BadRequestError, NotFoundError
+
+_EXC_SELECT = (
+    "SELECT ce.id, ce.unit_id, ce.kind, ce.override_text, ce.note, ce.created_at,"
+    "       u.doc_id,"
+    "       COALESCE(d.title, '') AS doc_title,"
+    "       SUBSTR(u.text_norm, 1, 200)  AS unit_text"
+    " FROM curation_exceptions ce"
+    " JOIN units u    ON u.unit_id = ce.unit_id"
+    " JOIN documents d ON d.doc_id  = u.doc_id"
+)
+
+
+def _int_or(value: object, default: int | None) -> int | None:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _exc_row(row: tuple) -> dict[str, Any]:
+    return {
+        "id": row[0], "unit_id": row[1], "kind": row[2], "override_text": row[3],
+        "note": row[4], "created_at": row[5], "doc_id": row[6],
+        "doc_title": row[7] or None, "unit_text": row[8] or None,
+    }
+
+
+def list_exceptions(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """All curation exceptions, optionally filtered by doc_id (GET/POST /curate/exceptions)."""
+    doc_id = body.get("doc_id")
+    if doc_id is not None:
+        rows = conn.execute(
+            _EXC_SELECT + " WHERE u.doc_id = ? ORDER BY ce.unit_id", (int(doc_id),)
+        ).fetchall()
+    else:
+        rows = conn.execute(_EXC_SELECT + " ORDER BY u.doc_id, ce.unit_id").fetchall()
+    exceptions = [_exc_row(r) for r in rows]
+    return {"exceptions": exceptions, "count": len(exceptions)}
+
+
+def set_exception(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """Create or replace a curation exception for a unit_id (POST /curate/exceptions/set).
+
+    Raises BadRequestError (missing unit_id/kind, override without text) or
+    NotFoundError (unit_id does not exist).
+    """
+    unit_id = body.get("unit_id")
+    kind = body.get("kind")
+    if unit_id is None or kind not in ("ignore", "override"):
+        raise BadRequestError("unit_id (int) and kind ('ignore'|'override') are required")
+    unit_id = int(unit_id)
+    override_text = body.get("override_text")
+    if kind == "override" and not override_text:
+        raise BadRequestError("override_text is required when kind = 'override'")
+    note = body.get("note")
+
+    row = conn.execute("SELECT unit_id FROM units WHERE unit_id = ?", (unit_id,)).fetchone()
+    if not row:
+        raise NotFoundError(f"unit_id {unit_id} not found")
+
+    conn.execute(
+        """
+        INSERT INTO curation_exceptions (unit_id, kind, override_text, note, created_at)
+        VALUES (?, ?, ?, ?, datetime('now'))
+        ON CONFLICT(unit_id) DO UPDATE SET
+            kind = excluded.kind,
+            override_text = excluded.override_text,
+            note = excluded.note,
+            created_at = excluded.created_at
+        """,
+        (unit_id, kind, override_text, note),
+    )
+    conn.commit()
+    return {
+        "unit_id": unit_id, "kind": kind, "override_text": override_text,
+        "note": note, "action": "set",
+    }
+
+
+def delete_exception(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """Delete the curation exception for a unit_id (POST /curate/exceptions/delete).
+
+    Raises BadRequestError if unit_id is missing. Returns ``deleted`` (bool).
+    """
+    unit_id = body.get("unit_id")
+    if unit_id is None:
+        raise BadRequestError("unit_id is required")
+    unit_id = int(unit_id)
+    cur = conn.execute("DELETE FROM curation_exceptions WHERE unit_id = ?", (unit_id,))
+    conn.commit()
+    return {"unit_id": unit_id, "deleted": cur.rowcount > 0}
+
+
+def record_apply_history(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """Insert one apply event into curation_apply_history (POST /curate/apply-history).
+
+    The sidecar trusts all fields (sourced from the frontend session) — no validation.
+    """
+    scope = body.get("scope", "all")
+    if scope not in ("doc", "all"):
+        scope = "all"
+    doc_id = body.get("doc_id")
+    if doc_id is not None:
+        doc_id = int(doc_id)
+
+    cur = conn.execute(
+        """
+        INSERT INTO curation_apply_history
+          (applied_at, scope, doc_id, doc_title,
+           docs_curated, units_modified, units_skipped,
+           ignored_count, manual_override_count,
+           preview_displayed_count, preview_units_changed, preview_truncated)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            body.get("applied_at") or "unknown",
+            scope,
+            doc_id,
+            body.get("doc_title"),
+            _int_or(body.get("docs_curated"), 0),
+            _int_or(body.get("units_modified"), 0),
+            _int_or(body.get("units_skipped"), 0),
+            _int_or(body.get("ignored_count"), None),
+            _int_or(body.get("manual_override_count"), None),
+            _int_or(body.get("preview_displayed_count"), None),
+            _int_or(body.get("preview_units_changed"), None),
+            1 if body.get("preview_truncated") else 0,
+        ),
+    )
+    conn.commit()
+    return {"id": cur.lastrowid}
+
+
+def list_apply_history(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
+    """List recent apply events, optionally filtered by doc_id/scope (limit<=200)."""
+    doc_id = body.get("doc_id")
+    scope = body.get("scope")
+    limit = min(_int_or(body.get("limit", 50), 50), 200)
+
+    sql = (
+        "SELECT id, applied_at, scope, doc_id, doc_title,"
+        "       docs_curated, units_modified, units_skipped,"
+        "       ignored_count, manual_override_count,"
+        "       preview_displayed_count, preview_units_changed, preview_truncated"
+        " FROM curation_apply_history"
+    )
+    conditions: list[str] = []
+    params: list[object] = []
+    if doc_id is not None:
+        conditions.append("doc_id = ?")
+        params.append(int(doc_id))
+    if scope is not None:
+        conditions.append("scope = ?")
+        params.append(scope)
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
+    sql += " ORDER BY applied_at DESC LIMIT ?"
+    params.append(limit)
+
+    rows = conn.execute(sql, params).fetchall()
+    events = [
+        {
+            "id": row[0], "applied_at": row[1], "scope": row[2], "doc_id": row[3],
+            "doc_title": row[4], "docs_curated": row[5], "units_modified": row[6],
+            "units_skipped": row[7], "ignored_count": row[8], "manual_override_count": row[9],
+            "preview_displayed_count": row[10], "preview_units_changed": row[11],
+            "preview_truncated": bool(row[12]),
+        }
+        for row in rows
+    ]
+    return {"events": events, "count": len(events)}

--- a/src/multicorpus_engine/sidecar.py
+++ b/src/multicorpus_engine/sidecar.py
@@ -2174,134 +2174,38 @@ class _CorpusHandler(BaseHTTPRequestHandler):
         return to_preview(parsed.units, limit)
 
     def _handle_curate_exceptions_list(self, body: dict) -> None:
-        """Return all curation exceptions for a given doc_id (or all if absent).
-
-        Enriched for Level 8A: response now includes doc_id, doc_title and
-        unit_text (truncated to 200 chars) for each exception row, so the
-        admin panel can display useful context without extra queries.
-        """
-        doc_id = body.get("doc_id")
+        # Thin adapter over the curate service (audit P0-1 / A-01).
+        from multicorpus_engine.services.curate_service import list_exceptions
         with self._lock():
-            conn = self._conn()
-            if doc_id is not None:
-                rows = conn.execute(
-                    """
-                    SELECT ce.id, ce.unit_id, ce.kind, ce.override_text, ce.note, ce.created_at,
-                           u.doc_id,
-                           COALESCE(d.title, '') AS doc_title,
-                           SUBSTR(u.text_norm, 1, 200)  AS unit_text
-                    FROM curation_exceptions ce
-                    JOIN units u    ON u.unit_id = ce.unit_id
-                    JOIN documents d ON d.doc_id  = u.doc_id
-                    WHERE u.doc_id = ?
-                    ORDER BY ce.unit_id
-                    """,
-                    (int(doc_id),),
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    """
-                    SELECT ce.id, ce.unit_id, ce.kind, ce.override_text, ce.note, ce.created_at,
-                           u.doc_id,
-                           COALESCE(d.title, '') AS doc_title,
-                           SUBSTR(u.text_norm, 1, 200)  AS unit_text
-                    FROM curation_exceptions ce
-                    JOIN units u    ON u.unit_id = ce.unit_id
-                    JOIN documents d ON d.doc_id  = u.doc_id
-                    ORDER BY u.doc_id, ce.unit_id
-                    """
-                ).fetchall()
-        exceptions = [
-            {
-                "id": row[0],
-                "unit_id": row[1],
-                "kind": row[2],
-                "override_text": row[3],
-                "note": row[4],
-                "created_at": row[5],
-                "doc_id": row[6],
-                "doc_title": row[7] or None,
-                "unit_text": row[8] or None,
-            }
-            for row in rows
-        ]
-        self._send_json(success_payload({"exceptions": exceptions, "count": len(exceptions)}))
+            data = list_exceptions(self._conn(), body)
+        self._send_json(success_payload(data))
 
     def _handle_curate_exceptions_set(self, body: dict) -> None:
-        """Create or replace a curation exception for a unit_id.
-
-        Required fields: unit_id (int), kind ('ignore' | 'override')
-        When kind = 'override': override_text (str, non-empty) is required.
-        Optional: note (str)
-        """
-        unit_id = body.get("unit_id")
-        kind = body.get("kind")
-        if unit_id is None or kind not in ("ignore", "override"):
-            self._send_error(
-                "unit_id (int) and kind ('ignore'|'override') are required",
-                code=ERR_BAD_REQUEST,
-                http_status=400,
-            )
+        # Thin adapter over the curate service.
+        from multicorpus_engine.services.curate_service import set_exception
+        from multicorpus_engine.services.errors import BadRequestError, NotFoundError
+        try:
+            with self._lock():
+                data = set_exception(self._conn(), body)
+        except BadRequestError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-        unit_id = int(unit_id)
-        override_text = body.get("override_text")
-        if kind == "override" and not override_text:
-            self._send_error(
-                "override_text is required when kind = 'override'",
-                code=ERR_BAD_REQUEST,
-                http_status=400,
-            )
+        except NotFoundError as exc:
+            self._send_error(exc.message, code=ERR_NOT_FOUND, http_status=exc.http_status)
             return
-        note = body.get("note")
-        with self._lock():
-            conn = self._conn()
-            # Verify unit exists
-            row = conn.execute(
-                "SELECT unit_id FROM units WHERE unit_id = ?", (unit_id,)
-            ).fetchone()
-            if not row:
-                self._send_error(
-                    f"unit_id {unit_id} not found",
-                    code=ERR_NOT_FOUND,
-                    http_status=404,
-                )
-                return
-            conn.execute(
-                """
-                INSERT INTO curation_exceptions (unit_id, kind, override_text, note, created_at)
-                VALUES (?, ?, ?, ?, datetime('now'))
-                ON CONFLICT(unit_id) DO UPDATE SET
-                    kind = excluded.kind,
-                    override_text = excluded.override_text,
-                    note = excluded.note,
-                    created_at = excluded.created_at
-                """,
-                (unit_id, kind, override_text, note),
-            )
-            conn.commit()
-        self._send_json(success_payload({
-            "unit_id": unit_id,
-            "kind": kind,
-            "override_text": override_text,
-            "note": note,
-            "action": "set",
-        }))
+        self._send_json(success_payload(data))
 
     def _handle_curate_exceptions_delete(self, body: dict) -> None:
-        """Delete the curation exception for a unit_id (if any)."""
-        unit_id = body.get("unit_id")
-        if unit_id is None:
-            self._send_error("unit_id is required", code=ERR_BAD_REQUEST, http_status=400)
+        # Thin adapter over the curate service.
+        from multicorpus_engine.services.curate_service import delete_exception
+        from multicorpus_engine.services.errors import BadRequestError
+        try:
+            with self._lock():
+                data = delete_exception(self._conn(), body)
+        except BadRequestError as exc:
+            self._send_error(exc.message, code=ERR_BAD_REQUEST, http_status=exc.http_status)
             return
-        unit_id = int(unit_id)
-        with self._lock():
-            conn = self._conn()
-            cur = conn.execute(
-                "DELETE FROM curation_exceptions WHERE unit_id = ?", (unit_id,)
-            )
-            conn.commit()
-            deleted = cur.rowcount
-        self._send_json(success_payload({"unit_id": unit_id, "deleted": deleted > 0}))
+        self._send_json(success_payload(data))
 
     def _handle_curate_exceptions_export(self, body: dict) -> None:
         """Export curation exceptions to JSON or CSV.
@@ -2426,110 +2330,18 @@ class _CorpusHandler(BaseHTTPRequestHandler):
     # ─── Apply-history endpoints (Level 10A/10B) ──────────────────────────────
 
     def _handle_curate_apply_history_record(self, body: dict) -> None:
-        """Insert one apply event into curation_apply_history.
-
-        Called by the frontend immediately after each successful curation job.
-        All fields sourced from the frontend session — the sidecar trusts them.
-        """
-        scope = body.get("scope", "all")
-        if scope not in ("doc", "all"):
-            scope = "all"
-
-        doc_id = body.get("doc_id")
-        if doc_id is not None:
-            doc_id = int(doc_id)
-
-        # Coerce integer-like booleans
-        def _int(v, default=None):
-            try:
-                return int(v)
-            except (TypeError, ValueError):
-                return default
-
+        # Thin adapter over the curate service.
+        from multicorpus_engine.services.curate_service import record_apply_history
         with self._lock():
-            conn = self._conn()
-            cur = conn.execute(
-                """
-                INSERT INTO curation_apply_history
-                  (applied_at, scope, doc_id, doc_title,
-                   docs_curated, units_modified, units_skipped,
-                   ignored_count, manual_override_count,
-                   preview_displayed_count, preview_units_changed, preview_truncated)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    body.get("applied_at") or "unknown",
-                    scope,
-                    doc_id,
-                    body.get("doc_title"),
-                    _int(body.get("docs_curated"), 0),
-                    _int(body.get("units_modified"), 0),
-                    _int(body.get("units_skipped"), 0),
-                    _int(body.get("ignored_count")),
-                    _int(body.get("manual_override_count")),
-                    _int(body.get("preview_displayed_count")),
-                    _int(body.get("preview_units_changed")),
-                    1 if body.get("preview_truncated") else 0,
-                ),
-            )
-            conn.commit()
-            new_id = cur.lastrowid
-
-        self._send_json(success_payload({"id": new_id}))
+            data = record_apply_history(self._conn(), body)
+        self._send_json(success_payload(data))
 
     def _handle_curate_apply_history_list(self, body: dict) -> None:
-        """List recent apply events, optionally filtered by doc_id or scope.
-
-        Query-string / body params:
-          doc_id (int | None) — filter to that document; None = all
-          scope  (str | None) — 'doc' | 'all' | None (no filter)
-          limit  (int)        — max rows returned (default 50, max 200)
-        """
-        doc_id = body.get("doc_id")
-        scope  = body.get("scope")
-        limit  = min(_int_param(body.get("limit", 50), 50), 200)
-
-        sql = """
-            SELECT id, applied_at, scope, doc_id, doc_title,
-                   docs_curated, units_modified, units_skipped,
-                   ignored_count, manual_override_count,
-                   preview_displayed_count, preview_units_changed, preview_truncated
-            FROM curation_apply_history
-        """
-        conditions, params = [], []
-        if doc_id is not None:
-            conditions.append("doc_id = ?")
-            params.append(int(doc_id))
-        if scope is not None:
-            conditions.append("scope = ?")
-            params.append(scope)
-        if conditions:
-            sql += " WHERE " + " AND ".join(conditions)
-        sql += " ORDER BY applied_at DESC LIMIT ?"
-        params.append(limit)
-
+        # Thin adapter over the curate service.
+        from multicorpus_engine.services.curate_service import list_apply_history
         with self._lock():
-            rows = self._conn().execute(sql, params).fetchall()
-
-        events = [
-            {
-                "id":                      row[0],
-                "applied_at":              row[1],
-                "scope":                   row[2],
-                "doc_id":                  row[3],
-                "doc_title":               row[4],
-                "docs_curated":            row[5],
-                "units_modified":          row[6],
-                "units_skipped":           row[7],
-                "ignored_count":           row[8],
-                "manual_override_count":   row[9],
-                "preview_displayed_count": row[10],
-                "preview_units_changed":   row[11],
-                "preview_truncated":       bool(row[12]),
-            }
-            for row in rows
-        ]
-        self._send_json(success_payload({"events": events, "count": len(events)}))
+            data = list_apply_history(self._conn(), body)
+        self._send_json(success_payload(data))
 
     def _handle_curate_apply_history_export(self, body: dict) -> None:
         """Export apply history to JSON or CSV.

--- a/tests/services/test_curate_service.py
+++ b/tests/services/test_curate_service.py
@@ -1,0 +1,134 @@
+"""Direct unit tests for the curate service CRUD (audit P0-1 / A-01).
+
+Covers the curation-exceptions + apply-history CRUD without an HTTP server. The
+adapters are covered over HTTP by tests/test_sidecar_curate.py + the binary smoke
+(GET /curate/exceptions) in CI.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from multicorpus_engine.services.curate_service import (
+    delete_exception,
+    list_apply_history,
+    list_exceptions,
+    record_apply_history,
+    set_exception,
+)
+from multicorpus_engine.services.errors import BadRequestError, NotFoundError
+
+
+def _mk_unit(conn: sqlite3.Connection, text: str = "hello") -> tuple[int, int]:
+    cur = conn.execute(
+        "INSERT INTO documents (title, language, doc_role, created_at)"
+        " VALUES ('D', 'fr', 'standalone', datetime('now'))"
+    )
+    doc_id = cur.lastrowid
+    cur2 = conn.execute(
+        "INSERT INTO units (doc_id, unit_type, n, text_raw, text_norm) VALUES (?, 'line', 1, ?, ?)",
+        (doc_id, text, text),
+    )
+    conn.commit()
+    return doc_id, cur2.lastrowid
+
+
+# --- exceptions: set / list / delete --------------------------------------------
+def test_set_exception_creates_then_upserts(db_conn: sqlite3.Connection) -> None:
+    _, unit_id = _mk_unit(db_conn)
+    out = set_exception(db_conn, {"unit_id": unit_id, "kind": "ignore"})
+    assert out == {
+        "unit_id": unit_id, "kind": "ignore", "override_text": None,
+        "note": None, "action": "set",
+    }
+    # upsert to override
+    out2 = set_exception(
+        db_conn, {"unit_id": unit_id, "kind": "override", "override_text": "X", "note": "n"}
+    )
+    assert out2["kind"] == "override" and out2["override_text"] == "X"
+    # exactly one row (upsert, not insert)
+    assert list_exceptions(db_conn, {})["count"] == 1
+
+
+@pytest.mark.parametrize("body", [
+    {"kind": "ignore"},                        # missing unit_id
+    {"unit_id": 1, "kind": "bogus"},           # invalid kind
+])
+def test_set_exception_bad_request(db_conn: sqlite3.Connection, body: dict) -> None:
+    with pytest.raises(BadRequestError):
+        set_exception(db_conn, body)
+
+
+def test_set_exception_override_needs_text(db_conn: sqlite3.Connection) -> None:
+    _, unit_id = _mk_unit(db_conn)
+    with pytest.raises(BadRequestError):
+        set_exception(db_conn, {"unit_id": unit_id, "kind": "override"})
+
+
+def test_set_exception_unit_not_found(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(NotFoundError):
+        set_exception(db_conn, {"unit_id": 99999, "kind": "ignore"})
+
+
+def test_list_exceptions_enriched_and_filtered(db_conn: sqlite3.Connection) -> None:
+    doc_id, unit_id = _mk_unit(db_conn, text="bonjour")
+    set_exception(db_conn, {"unit_id": unit_id, "kind": "ignore"})
+    out = list_exceptions(db_conn, {})
+    assert out["count"] == 1
+    row = out["exceptions"][0]
+    assert row["unit_id"] == unit_id and row["doc_id"] == doc_id
+    assert row["doc_title"] == "D" and row["unit_text"] == "bonjour"
+    # doc_id filter
+    assert list_exceptions(db_conn, {"doc_id": doc_id})["count"] == 1
+    assert list_exceptions(db_conn, {"doc_id": doc_id + 999})["count"] == 0
+
+
+def test_delete_exception(db_conn: sqlite3.Connection) -> None:
+    _, unit_id = _mk_unit(db_conn)
+    set_exception(db_conn, {"unit_id": unit_id, "kind": "ignore"})
+    assert delete_exception(db_conn, {"unit_id": unit_id}) == {"unit_id": unit_id, "deleted": True}
+    # deleting again -> deleted False
+    assert delete_exception(db_conn, {"unit_id": unit_id}) == {"unit_id": unit_id, "deleted": False}
+
+
+def test_delete_exception_requires_unit_id(db_conn: sqlite3.Connection) -> None:
+    with pytest.raises(BadRequestError):
+        delete_exception(db_conn, {})
+
+
+# --- apply history: record / list -----------------------------------------------
+def test_record_and_list_apply_history(db_conn: sqlite3.Connection) -> None:
+    out = record_apply_history(db_conn, {
+        "applied_at": "2026-06-18T00:00:00Z", "scope": "doc", "doc_id": 5,
+        "doc_title": "T", "docs_curated": 1, "units_modified": 3,
+        "preview_truncated": True,
+    })
+    assert isinstance(out["id"], int)
+    events = list_apply_history(db_conn, {})["events"]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["scope"] == "doc" and ev["doc_id"] == 5 and ev["units_modified"] == 3
+    assert ev["preview_truncated"] is True           # stored 1 -> bool True
+    assert ev["ignored_count"] is None               # absent -> default None
+
+
+def test_record_apply_history_coerces_and_defaults(db_conn: sqlite3.Connection) -> None:
+    # bad scope -> 'all'; non-int docs_curated -> 0; missing applied_at -> 'unknown'
+    record_apply_history(db_conn, {"scope": "weird", "docs_curated": "NaN"})
+    ev = list_apply_history(db_conn, {})["events"][0]
+    assert ev["scope"] == "all"
+    assert ev["docs_curated"] == 0
+    assert ev["applied_at"] == "unknown"
+
+
+def test_list_apply_history_filters_and_limit(db_conn: sqlite3.Connection) -> None:
+    for i in range(3):
+        record_apply_history(db_conn, {"scope": "doc", "doc_id": 1, "applied_at": f"t{i}"})
+    record_apply_history(db_conn, {"scope": "all", "doc_id": 2, "applied_at": "tx"})
+    assert list_apply_history(db_conn, {"scope": "doc"})["count"] == 3
+    assert list_apply_history(db_conn, {"doc_id": 2})["count"] == 1
+    assert list_apply_history(db_conn, {"limit": 2})["count"] == 2
+    # limit is capped at 200 (huge request returns all 4, not an error)
+    assert list_apply_history(db_conn, {"limit": 10_000})["count"] == 4

--- a/tests/test_sidecar_curate.py
+++ b/tests/test_sidecar_curate.py
@@ -1,0 +1,133 @@
+"""HTTP tests for the curate-exceptions / apply-history endpoints (A-01 adapters).
+
+These cover the thin adapters end-to-end (wire codes + shapes) — there was no
+prior HTTP test for these routes. Runs in CI (the in-process server path); the
+service logic itself is unit-tested in tests/services/test_curate_service.py.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+
+def _http(method: str, url: str, payload: dict | None = None, token: str | None = None) -> tuple[int, dict]:
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        headers["Content-Type"] = "application/json; charset=utf-8"
+    if token:
+        headers["X-Agrafes-Token"] = token
+    req = Request(url, method=method, data=data, headers=headers)
+    try:
+        with urlopen(req, timeout=10.0) as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def _wait_health(base_url: str, tries: int = 50) -> None:
+    for _ in range(tries):
+        try:
+            code, body = _http("GET", f"{base_url}/health")
+            if code == 200 and body.get("ok") is True:
+                return
+        except Exception:
+            pass
+        time.sleep(0.05)
+    raise RuntimeError("Sidecar not ready")
+
+
+@pytest.fixture()
+def curate_env(tmp_path: Path):
+    from multicorpus_engine.db.connection import get_connection
+    from multicorpus_engine.db.migrations import apply_migrations
+    from multicorpus_engine.sidecar import CorpusServer
+
+    db_path = tmp_path / "curate.db"
+    conn = get_connection(db_path)
+    apply_migrations(conn)
+    cur = conn.execute(
+        "INSERT INTO documents (title, language, doc_role, created_at)"
+        " VALUES ('D', 'fr', 'standalone', datetime('now'))"
+    )
+    doc_id = cur.lastrowid
+    cur2 = conn.execute(
+        "INSERT INTO units (doc_id, unit_type, n, text_raw, text_norm) VALUES (?, 'line', 1, 'x', 'x')",
+        (doc_id,),
+    )
+    unit_id = cur2.lastrowid
+    conn.commit()
+    conn.close()
+
+    token = "curate-token"
+    server = CorpusServer(db_path=db_path, host="127.0.0.1", port=0, token=token)
+    server.start()
+    base = f"http://127.0.0.1:{server.actual_port}"
+    _wait_health(base)
+    try:
+        yield {"base": base, "token": token, "doc_id": doc_id, "unit_id": unit_id}
+    finally:
+        server.shutdown()
+
+
+def test_exceptions_get_empty(curate_env: dict) -> None:
+    code, body = _http("GET", f"{curate_env['base']}/curate/exceptions")
+    assert code == 200, body
+    assert body["exceptions"] == [] and body["count"] == 0
+
+
+def test_exceptions_set_validation_400(curate_env: dict) -> None:
+    code, body = _http(
+        "POST", f"{curate_env['base']}/curate/exceptions/set",
+        {"kind": "ignore"}, token=curate_env["token"],
+    )
+    assert code == 400, body
+    assert body["ok"] is False
+
+
+def test_exceptions_set_unit_not_found_404(curate_env: dict) -> None:
+    code, body = _http(
+        "POST", f"{curate_env['base']}/curate/exceptions/set",
+        {"unit_id": 99999, "kind": "ignore"}, token=curate_env["token"],
+    )
+    assert code == 404, body
+
+
+def test_exceptions_set_then_list_then_delete(curate_env: dict) -> None:
+    base, token, unit_id = curate_env["base"], curate_env["token"], curate_env["unit_id"]
+    code, body = _http(
+        "POST", f"{base}/curate/exceptions/set",
+        {"unit_id": unit_id, "kind": "override", "override_text": "Y"}, token=token,
+    )
+    assert code == 200, body
+    assert body["action"] == "set" and body["override_text"] == "Y"
+
+    code, body = _http("GET", f"{base}/curate/exceptions")
+    assert code == 200
+    assert body["count"] == 1 and body["exceptions"][0]["unit_id"] == unit_id
+
+    code, body = _http("POST", f"{base}/curate/exceptions/delete", {"unit_id": unit_id}, token=token)
+    assert code == 200
+    assert body["deleted"] is True
+
+
+def test_apply_history_record_then_list(curate_env: dict) -> None:
+    base, token = curate_env["base"], curate_env["token"]
+    code, body = _http(
+        "POST", f"{base}/curate/apply-history/record",
+        {"scope": "all", "docs_curated": 2}, token=token,
+    )
+    assert code == 200, body
+    assert isinstance(body["id"], int)
+
+    code, body = _http("GET", f"{base}/curate/apply-history")
+    assert code == 200
+    assert body["count"] == 1
+    assert body["events"][0]["docs_curated"] == 2


### PR DESCRIPTION
## A-01 — service-layer extraction, tranche 5 (pivoted from export)

The 5 DB-pure curate handlers become **thin adapters**; validation + SQL move to `services/curate_service.py`:
- `exceptions`: `list` / `set` (upsert) / `delete`
- `apply_history`: `record` / `list`

All use a **uniform write-lock**; byte-identical mapping `BadRequestError → ERR_BAD_REQUEST`, `NotFoundError → ERR_NOT_FOUND` (the codes these endpoints used). Reads were already lock-wrapped in the originals — kept so.

### Why pivoted from `export`
Deepening `export` revealed a poor candidate: **low A-01 value** (format already in `exporters/` for half) **and inconsistent per-handler lock granularity** (`conllu`/`ske`/`token_query_csv` lock everything; `align_csv`/`run_report` lock nothing; `tei` locks only the doc-id fetch). A clean byte-identical split wasn't worth it, so we pivoted to curate-CRUD (richer inline DB logic, uniform lock). Documented in the tracker.

### Out of scope (kept as handlers, documented)
`curate_preview` (server-coupled, 220 l), the `*_export` handlers (bulky inline formatting + file writes), `curate` (delegates to `curation.py`).

### Coverage
- `tests/services/test_curate_service.py` — 11 local tests via `db_conn` (upsert, validation, not-found, filters, limit cap, coercions).
- **NEW** `tests/test_sidecar_curate.py` — HTTP adapters end-to-end (there was no prior HTTP test for these routes): GET empty, set 400/404/200, delete, apply-history record+list. Runs in CI.
- Binary smoke gains `GET /curate/exceptions`.
- 526 non-sidecar tests pass; ruff `src tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)