### PR TITLE
ci(T-03): run the tauri-prep vitest suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,11 @@ jobs:
       - name: Build tauri-prep
         run: npm --prefix tauri-prep run build
 
+      # T-03: the 394 tauri-prep vitest tests existed but were never run in CI —
+      # only `build` was. Gate them now (deps already installed above).
+      - name: Run tauri-prep unit tests (vitest)
+        run: npm --prefix tauri-prep test
+
       - name: Install tauri-app deps
         run: npm --prefix tauri-app ci
 


### PR DESCRIPTION
## Why
The **394 tauri-prep vitest tests** (20 files) existed but **were never executed in CI** — the `TypeScript builds` job only ran `build` (+ a single ad-hoc node test for tauri-app). So the front-end suite gated nothing; a regression in tauri-prep would pass CI.

## Change
Add one step — `npm --prefix tauri-prep test` — to the existing `build-ts` job (deps already `npm ci`'d there). The 394 tests now run and gate.

## Validation
Locally: **394 passed (20 files, 1.8s)** — the suite is healthy, not rotted. This PR's own CI run confirms the step is green on Linux.

First step of the front-end test gap (T-03). Next: stand up vitest for the 0-test apps (`tauri-app`, `tauri-shell`) and cover their pure-logic units (`state`, `buildFtsQuery`, `diagnostics`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)