### PR TITLE
test(tauri-shell): tighten two loose assertions from the .mjs migration

### DIFF
--- a/tauri-shell/src/__tests__/diagnostics.test.ts
+++ b/tauri-shell/src/__tests__/diagnostics.test.ts
@@ -100,7 +100,9 @@ describe("formatDiagnosticsText", () => {
     expect(txt).toContain("2.00 MB");
     expect(txt).toContain("3 (1 pinned)");
     expect(txt).toContain("## Preferences");
-    expect(txt).toContain("strict");
+    // Full line, not bare "strict" — that substring also appears in
+    // "TEI profile : parcolab_strict", so it would pass even if qa_policy broke.
+    expect(txt).toContain("QA policy        : strict");
     expect(txt).not.toContain("Collection Errors");
     expect(txt).not.toContain("Session Log");
     expect(txt).toContain("End of diagnostic report");

--- a/tauri-shell/src/__tests__/telemetry.test.ts
+++ b/tauri-shell/src/__tests__/telemetry.test.ts
@@ -137,7 +137,10 @@ describe("aggregateTelemetry", () => {
         { event: "stage_completed", stage: "x", success: "not-bool", duration_ms: "nope" }, // wrong types
       ]),
     );
-    expect(s.by_stage.unknown ?? s.by_stage.x).toBeDefined();
+    // Both fallback buckets must exist: the stage-less record → "unknown",
+    // the present-but-wrong-typed record → "x" (with safe 0ms / not-success).
+    expect(s.by_stage.unknown).toEqual({ completed: 1, success: 0, avg_duration_ms: 0 });
+    expect(s.by_stage.x).toEqual({ completed: 1, success: 0, avg_duration_ms: 0 });
     expect(s.caps_hit.find((c) => c.cap_name === "unknown")).toBeDefined();
     expect(s.top_errors.find((e) => e.error_class === "unknown")).toBeDefined();
   });


### PR DESCRIPTION
Follow-up from the adversarial pass on the merged #62. Two assertions ported verbatim from the deleted `.mjs` copies passed without verifying their claim:

1. **`diagnostics.test.ts`** — `toContain("strict")` for the QA-policy line also matches `TEI profile : parcolab_strict`, so it would pass even if `qa_policy` rendering broke. → now asserts the full `QA policy        : strict` line (consistent with the sibling `(not set)` test).
2. **`telemetry.test.ts`** — the malformed-payload test checked only one of the two fallback stage buckets via `unknown ?? x`. → now asserts **both** buckets with their exact safe defaults (`{completed:1, success:0, avg_duration_ms:0}`): `"unknown"` (stage-less record) and `"x"` (present stage, wrong-typed `success`/`duration_ms`).

Test-only; production behavior unchanged. Local: `tauri-shell` vitest **28 passed**, `tsc` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)