### PR TITLE
refactor(u01): reconcile sidecarClient shared types to prep canonical (PR1a)

### DIFF
--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -38,6 +38,7 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | — | — | — | ✅ bonus | CI déclenchée aussi sur `development` (les gates ne tiraient que sur `main`). `1b12520` |
 | — | — | — | ✅ bonus | Tests front **gatés en CI** : les 394 tests Vitest de Prep existaient mais ne tournaient jamais (seul `build` tournait). Jobs Vitest prep/app/shell ajoutés dans `ci.yml` + `smoke.yml` ; `.mjs` ad-hoc (qui testaient des copies inline) migrés vers du Vitest important le vrai code. PR #59→#63. |
 | D-04 | 🟡 | P1-7 | ✅ corrigé | **Ce fichier** (vue inverse finding→statut→commit) |
+| T-02 | 🟠 | P0-3 | ✅ corrigé | Suites dédiées `test_telemetry.py` (13) + `test_curation.py` (35) important le vrai code (étaient testés seulement indirectement). `curation.py` **100 %** ; coverage projet 61,94 %→66,82 %. PR #65 |
 | A-05 | — | — | ❌ retiré | Réfuté en passe 2 : les index secondaires existent (`003_alignment.sql`, `012_tokens.sql`) |
 
 ### Ouverts
@@ -50,7 +51,6 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | Q-02 | 🟠 | P0-1 | 🟦 partiel | Fonctions géantes : `_handle_import` 242 l → adapter ~15 l (A-01 #46) ; **`_build_hits`/`_build_hits_regex` dédupliqués** via `_build_hits_core` partagé (paramétré matchers + `coerce_text_norm` + `log_hits` ; byte-identique, logs inclus) — le chemin regex, jamais testé, gagne une couverture directe. Reste : `_handle_query` 221 l (délégateur, laissé avec les autres). |
 | Q-04 | 🟡 | P2-13 | ⬜ ouvert | Typage hétérogène ; pas de TypedDict pour les shapes de contrat |
 | Q-05 | 🟡 | — | ⬜ ouvert | Matcher CQL : pas de cap global documenté (gardes présentes) |
-| T-02 | 🟠 | P0-3 | ⬜ ouvert | Branches cœur `telemetry.py` / `curation.py` sans test direct |
 | T-03 | 🟡 | P1-6 | ⬜ ouvert | 11 fichiers de tests versionnés à isoler sous `tests/contracts/` |
 | T-04 | 🟡 | — | ⬜ ouvert | Fragilités timing (23 `time.sleep`) ; 8 tests exigent `NO_PROXY` en local |
 | T-05 | 🟠 | — | ⬜ ouvert | E2E Tauri quasi inexistant (pas de Playwright/WebDriver). Mitigation partielle : render-smoke DOM (happy-dom) côté shell — `styleRegistry`, `diagnostics`, `telemetry` (PR #61→#63) ; **≠ vrai E2E**, qui reste ouvert. |
@@ -58,7 +58,7 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | S-02 | 🟡 | P1-8 | ⬜ ouvert | Race POSIX sur le portfile (`O_EXCL`/umask absents) |
 | S-03 | 🟡 | P0-2 | 🟦 partiel | Sink type-safe `setHtml`/`safeHtml\`\`` + ESLint no-unsanitized (prep) ; 3 fichiers migrés, `f858c78`. Aucun vrai XSS trouvé (escapers tous vérifiés). **Reste** : 92 sites des 4 écrans géants + app/shell + job CI bloquant. Décision de reprise en attente (grind complet vs suppressions pour les géants). |
 | S-04 | 🟡 | P1-8 | ⬜ ouvert | `exporters/tei.py` importe `xml.etree` non défusé (risque nul aujourd'hui) |
-| U-01 | 🟠 | P1-4 | ⬜ ouvert | `sidecarClient.ts` dupliqué/divergent ; le shell importe **les deux** clients |
+| U-01 | 🟠 | P1-4 | 🟦 partiel | `sidecarClient.ts` dupliqué/divergent (app 1434 l. / prep 2984 l. ; 25 symboles communs, 17 divergents). **PR1a** : 9 types réconciliés byte-identiques — app adopte les canoniques prep (`Conn`, `DocumentRecord`, `ImportOptions`, `ImportResponse`, `TokenRecord`, `FamilyStats`, `FamilyRecord` + support `FamilyChildEntry`/`FamilyRatioWarning`), `tsc`/builds verts, zéro changement runtime. Reste : PR1b (fonctions divergentes — `getActiveConn`, `listConventions`, conventions CRUD, `ensureRunning`… + helpers prep-only) puis PR2 (extraction byte-identique du cœur → le shell ne bundlera plus qu'un chunk client). |
 | U-02 | 🟠 | P2-11 | ⬜ ouvert | Écrans Prep monolithiques (Curation ~3 800 l., Metadata ~3 200 l.) |
 | U-03 | 🟡 | P2-11 | 🟦 partiel | `tauri-app` : 14 tests Vitest (happy-dom) sur le **vrai** `features/search.ts` (`buildFtsQuery`/`isSimpleInput`), gatés en CI (PR #60). Reste : couverture large des 8 112 l. (concordancier, état, rendu). |
 | U-04 | 🟡 | P2-12 | ⬜ ouvert | Signalisation de statut fragmentée entre READMEs |

--- a/tauri-app/src/lib/sidecarClient.ts
+++ b/tauri-app/src/lib/sidecarClient.ts
@@ -56,12 +56,18 @@ export interface QueryHit {
 
 export interface TokenRecord {
   token_id: number;
+  doc_id: number;
+  unit_id: number;
+  unit_n: number;
+  external_id: number | null;
+  sent_id: number;
   position: number;
-  word?: string | null;
-  lemma?: string | null;
-  upos?: string | null;
-  xpos?: string | null;
-  feats?: string | null;
+  word: string | null;
+  lemma: string | null;
+  upos: string | null;
+  xpos: string | null;
+  feats: string | null;
+  misc: string | null;
 }
 
 export interface AlignedUnit {
@@ -161,19 +167,41 @@ export interface ImportOptions {
     | "docx_paragraphs"
     | "odt_paragraphs"
     | "odt_numbered_lines"
-    | "tei";
+    | "tei"
+    | "conllu";
   path: string;
   language?: string;
   title?: string;
   doc_role?: string;
   resource_type?: string;
+  tei_unit?: "p" | "s";
+  check_filename?: boolean;
+  /** When set, creates a translation_of relation to this parent after import. */
+  family_root_doc_id?: number;
+  /**
+   * For `docx_numbered_lines` ONLY — 1-based index of the column to extract
+   * from tables (typical case: DOCX bilingue 2-col, set to 1 for the original
+   * column or 2 for the translation). Leave undefined to keep the legacy
+   * behavior (tables ignored). Ignored silently by other importers.
+   */
+  column_index?: number;
 }
 
 export interface ImportResponse {
   ok: boolean;
   doc_id: number;
-  units_line: number;
-  units_total: number;
+  units_line?: number;
+  units_total?: number;
+  /** True when a translation_of relation was freshly inserted. */
+  relation_created?: boolean;
+  /** Id of the doc_relations row (new or pre-existing). */
+  relation_id?: number;
+  /** Number of tables walked (>= 0 when column_index was set). */
+  tables_processed?: number;
+  /** Rows where the requested column did not exist (table too narrow / merged). */
+  rows_skipped_short?: number;
+  /** Nested sub-tables skipped during extraction. */
+  nested_tables_skipped?: number;
 }
 
 export interface IndexResponse {
@@ -187,9 +215,38 @@ export interface DocumentRecord {
   language: string;
   doc_role: string | null;
   resource_type: string | null;
+  workflow_status?: "draft" | "review" | "validated";
+  validated_at?: string | null;
+  validated_run_id?: string | null;
+  /** Absolute path recorded at import (for duplicate detection in Prep). */
   source_path?: string | null;
+  /** SHA-256 hex of source file at import. */
   source_hash?: string | null;
+  /** Number of token rows available for this document. */
+  token_count?: number;
+  /** Lightweight annotation state derived from token presence. */
+  annotation_status?: "missing" | "annotated";
+  author_lastname?: string | null;
+  author_firstname?: string | null;
+  /** Free-form date string: "2024", "2024-03", "2024-03-15", etc. */
+  doc_date?: string | null;
+  translator_lastname?: string | null;
+  translator_firstname?: string | null;
+  /** Titre de l'œuvre (identique VO et traduction, ex. "Les Misérables"). */
+  work_title?: string | null;
+  /** Lieu de publication (ex. "Paris"). */
+  pub_place?: string | null;
+  /** Éditeur / édition (ex. "Gallimard"). */
+  publisher?: string | null;
   unit_count: number;
+  /** First unit n that belongs to the main text (units with n < text_start_n are paratext). Null = no boundary. */
+  text_start_n?: number | null;
+  /**
+   * True when the FTS index is stale for this doc — at least one line unit
+   * is absent from / divergent in `fts_units`. Dérivé côté backend
+   * (indexer.stale_doc_ids), pas un flag persisté.
+   */
+  fts_stale?: boolean;
 }
 
 export interface QueryFacetsOptions {
@@ -261,12 +318,9 @@ export interface UnitContextResponse {
 export interface Conn {
   baseUrl: string;
   token: string | null;
-  /** POST a write operation (injects token header if present). */
   post(path: string, body: unknown): Promise<unknown>;
-  /** PUT a write operation (injects token header if present). */
-  put(path: string, body: unknown): Promise<unknown>;
-  /** POST a read-only operation (no token required). */
   get(path: string): Promise<unknown>;
+  put(path: string, body: unknown): Promise<unknown>;
 }
 
 // ─── Internal state ───────────────────────────────────────────────────────────
@@ -1225,19 +1279,11 @@ export async function listDocuments(conn: Conn): Promise<DocumentRecord[]> {
 
 // ─── Document families ────────────────────────────────────────────────────────
 
-export interface FamilyChild {
-  doc_id: number;
-  relation_type: string;
-  doc: {
-    doc_id: number;
-    title: string | null;
-    language: string | null;
-    doc_role: string | null;
-    workflow_status: string | null;
-  } | null;
-  segmented: boolean;
-  seg_count: number;
-  aligned_to_parent: boolean;
+export interface FamilyRatioWarning {
+  child_doc_id: number;
+  parent_segs: number;
+  child_segs: number;
+  ratio_pct: number;
 }
 
 export interface FamilyStats {
@@ -1246,18 +1292,24 @@ export interface FamilyStats {
   parent_seg_count: number;
   aligned_pairs: number;
   total_pairs: number;
+  validated_docs: number;
   completion_pct: number;
+  ratio_warnings: FamilyRatioWarning[];
+}
+
+export interface FamilyChildEntry {
+  doc_id: number;
+  relation_type: string;
+  doc: DocumentRecord | null;
+  segmented: boolean;
+  seg_count: number;
+  aligned_to_parent: boolean;
 }
 
 export interface FamilyRecord {
   family_id: number;
-  parent: {
-    doc_id: number;
-    title: string | null;
-    language: string | null;
-    doc_role: string | null;
-  } | null;
-  children: FamilyChild[];
+  parent: DocumentRecord | null;
+  children: FamilyChildEntry[];
   stats: FamilyStats;
 }
 


### PR DESCRIPTION
**U-01, étape 1/3.** Les deux clients sidecar (`tauri-app` 1434 l. / `tauri-prep` 2984 l.) partagent 25 symboles exportés, dont **17 divergents**. Cette PR rend les **types** divergents byte-identiques en adoptant les définitions canoniques (plus riches) de prep dans tauri-app — **changement de types pur, aucun comportement runtime touché.**

### Adopté dans `tauri-app/src/lib/sidecarClient.ts`
- `Conn` (ordre des méthodes), `DocumentRecord` (+champs workflow/méta optionnels), `ImportOptions` (+conllu/column_index…), `ImportResponse` (`units_*` désormais optionnels + champs relation/table), `TokenRecord` (+doc_id/unit_id/misc…), `FamilyStats` (+validated_docs/ratio_warnings), `FamilyRecord` (parent → `DocumentRecord`, children → `FamilyChildEntry`)
- nouveaux types support `FamilyChildEntry`, `FamilyRatioWarning`
- suppression de `FamilyChild` (devenu inutilisé)

Les blocs ont été copiés **octet par octet** depuis prep par script (les JSDoc FR de prep ont des accents — pas de re-saisie, pas de corruption d'encodage).

### Sûreté (sites d'appel vérifiés)
`FamilyChild` inutilisé ailleurs ; `units_line`/`units_total` jamais lus dans l'app ; l'app ne construit aucun de ces types ; `fam.parent.*` / `children.map` restent valides sous `DocumentRecord`/`FamilyChildEntry`.

### Vérifs
- 9 types désormais **byte-identiques** à prep
- `tauri-app` : tsc 0 + 14 vitest + build complet verts
- `tauri-shell` : tsc 0 (inclut app+prep)
- diff **types-only** (aucun corps de fonction modifié)

### Tracker
T-02 → ✅ corrigé (déplacé en Traités) ; U-01 → 🟦 partiel (PR1a notée). Suite : **PR1b** (fonctions divergentes) → **PR2** (extraction byte-identique du cœur → le shell ne bundlera plus qu'un chunk client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)