### PR TITLE
docs: roadmap post-audit + réconciliation backlogs vérifiée au code (D-01)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+AGRAFES is a monorepo for a multilingual corpus tool (import → index → query → align → curate → export). It has two layers:
+
+- **`src/multicorpus_engine/`** — a UI-independent Python core engine, exposed two ways:
+  - a **CLI** (`multicorpus`, entry `multicorpus_engine.cli:main`) that emits **exactly one JSON object per command** on stdout (exit `0` ok / `1` error);
+  - a **persistent HTTP sidecar** (`multicorpus serve`) that the desktop apps talk to.
+- **`tauri-*/`** — four TypeScript/Vite/Tauri front-ends (see *Front-ends* below).
+
+The database is **strictly local SQLite** (FTS-backed). The engine never depends on a UI; the CLI must keep working even when the sidecar isn't used.
+
+## Common commands
+
+### Python engine
+
+```bash
+pip install -e ".[dev]"          # editable install + dev deps (pytest, ruff)
+pytest tests/test_foo.py::test_bar   # run a single test
+pytest -k "import and not sidecar"   # run a subset by keyword
+ruff check src tests             # lint — must cover BOTH src and tests (CI scope)
+```
+
+- `pythonpath=["src"]` is set in `pyproject.toml`, so plain `pytest` works without `PYTHONPATH=src`.
+- **Do not run the full `tests/` suite locally.** The `test_sidecar_*` tests spawn a real sidecar subprocess that does not start reliably outside CI and appears to hang. Target with `-k`/explicit paths locally; let CI run the full suite.
+- **Replicate the CI gate before committing**: `ruff check src tests` (not just `src`) + the relevant pytest scope. A narrower scope has missed CI failures before.
+
+### Front-ends (per package: `tauri-prep`, `tauri-app`, `tauri-shell`, `tauri-fixture`)
+
+```bash
+npm --prefix tauri-prep ci        # install
+npm --prefix tauri-prep run build # tsc + vite build
+npm --prefix tauri-prep test      # vitest run
+npm --prefix tauri-prep run dev   # vite dev server
+```
+
+`tauri-shell` imports `tauri-prep` and `tauri-app` **at source level**, so building/testing the shell requires `npm ci` in all three first (their versions are coupled — see *Front-ends*).
+
+### Sidecar binary (PyInstaller)
+
+```bash
+pip install -e ".[packaging]"
+python scripts/build_sidecar.py --preset tauri --format onefile   # canonical app
+python scripts/build_sidecar.py --preset shell                     # shell app
+python scripts/build_sidecar.py --preset fixture                  # e2e fixture
+python scripts/smoke_sidecar.py <out>/sidecar-manifest.json        # serve + /health smoke
+```
+
+## CI (`.github/workflows/ci.yml`) — what must pass
+
+1. **Ruff** — `ruff check src tests` (rule set is conservative: `E4/E7/E9/F`, see `[tool.ruff]`).
+2. **Pytest + coverage** — `--cov-fail-under=60` (the `35` in `pyproject.toml` is a stale comment; the gate is 60 in CI).
+3. **Contract freeze** — `docs/openapi.json` and `tests/snapshots/openapi_paths.json` must match the spec generated from `sidecar_contract.py`. Endpoints can never be *removed*; *adding* one fails CI until you regenerate (see below).
+4. **TS builds + vitest** for `tauri-prep`, `tauri-app`, `tauri-shell`.
+5. **Sidecar binary** builds on Linux and answers `--help` + smoke.
+6. **Sidecar growth gate** (`.github/workflows/sidecar-growth-gate.yml`) — fires on any PR touching `sidecar.py`. Blocks the PR if **net growth (`add − del`) of `sidecar.py` exceeds 500 lines over a rolling 90-day window**. New features that grow `sidecar.py` past the threshold require splitting the file by domain first. Emergency override only for critical security fixes via a `Sidecar-Growth-Override:` trailer in the PR's head commit. **This directly constrains WebDAV Phase 2** — keep the new handlers thin (logic in `services/`/`remote/`) so they add few net lines.
+
+## Architecture
+
+### Engine core (`src/multicorpus_engine/`)
+
+- **Data model.** Imported documents become `documents` (with `source_hash` for dedup, `source_path` for provenance) and `units` rows. A unit is `unit_type="line"` (indexed in FTS, may carry an `external_id` for alignment) or `unit_type="structure"` (preserved, not indexed). Text is stored as `text_raw` (verbatim) and `text_norm` (normalized for search). These conventions are ADRs — **`docs/DECISIONS.md` is the source of truth** for separator/normalization/alignment rules; read it before touching import or normalization.
+- **Importers** live in `importers/`; the `mode → importer` mapping is centralized in **`importers/dispatch.py` (`dispatch_import`)** — the single dispatch point shared by CLI `import`, CLI `import-remote`, and the sidecar. Do not reintroduce per-call-site dispatch copies.
+- **Runs.** Every import/index/mutation creates a run; logs go to `<db_dir>/runs/<run_id>/run.log`. One file → one run.
+- **Schema.** The authoritative schema is the numbered SQL files in **`migrations/` (root)** (`001_initial_schema.sql`, `002_fts5_index.sql`, …); `db/connection.py` + `db/migrations.py` apply them. Add a new numbered file rather than editing an applied one.
+
+### Sidecar (`sidecar.py` + `services/` + `sidecar_jobs.py` + `sidecar_contract.py`)
+
+- Two integration modes (`docs/INTEGRATION_TAURI.md`): **Mode A** = Tauri spawns the CLI and parses stdout JSON (fallback, always available); **Mode B** = persistent HTTP sidecar on loopback (recommended UX). A `.agrafes_sidecar.json` portfile next to the DB holds host/port/pid/token; write endpoints require the `X-Agrafes-Token` header when started with `--token auto`.
+- `sidecar.py` (~8.5k lines) is an `http.server` handler class. `do_POST` has an **explicit allowlist of write paths** (`_write_paths`) — new POST routes must be added there; writes go through `with self._lock()`.
+- **Domain logic is being extracted into `services/<dom>_service.py`** (audit A-01): pure functions `(conn, …)` that raise typed errors from `services/errors.py` (`ValidationError`/`NotFoundError`/`ConflictError`/`BadRequestError`); the handler becomes a thin adapter that owns the write-lock and maps each typed error to the endpoint's **historical** wire code. Responses must stay byte-identical (the contract freeze enforces this). **A-01 is intentionally parked** — 7 services are extracted (import, conventions, doc_relations, documents, curate, units, tokens); the rest (delegators + stateful/coupled handlers) are deliberately left. See `docs/AUDIT_FOLLOW_UP.md`. Follow the established service/adapter protocol when adding new endpoint logic.
+- Async/long-running work uses **`JobManager`** (`sidecar_jobs.py`) with per-stage progress events.
+
+### Adding or changing a sidecar endpoint
+
+1. Implement domain logic in `services/` (pure, typed errors) and a thin adapter handler in `sidecar.py`; register the route, and add it to `_write_paths` if it mutates.
+2. Update `sidecar_contract.py`, then run `python scripts/export_openapi.py` and **commit the regenerated `docs/openapi.json` + `tests/snapshots/openapi_paths.json`** — otherwise the contract-freeze CI job fails.
+3. Add a read-only GET to `scripts/smoke_sidecar.py` coverage where applicable; service test locally (with a `db_conn`), HTTP test runs in CI.
+
+### Front-ends (`tauri-*`)
+
+- **`tauri-prep`** — the *préparation* app ("Constituer"): import, segmentation/roles, curation, alignment, metadata, annotation, exports (`src/screens/`). Talks to the engine via `src/lib/sidecarClient.ts`.
+- **`tauri-app`** — the *concordancier* (search/Explorer): query/KWIC UI (`src/features/`).
+- **`tauri-shell`** — the **unified desktop app shipped to users**: a single webview that embeds prep + app as modules (`src/modules/constituerModule.ts`, `explorerModule.ts`, `rechercheModule.ts`) plus the Python sidecar in one signed/notarized binary. Because it imports prep and app at source level, **their versions are coupled and a JS fault in one can take down the whole webview** (see `HANDOFF_SHELL.md`).
+- **`tauri-fixture`** — minimal harness used by the sidecar e2e workflow.
+- **`tauri/`** — holds `src-tauri/binaries/`, the canonical output dir for the packaged sidecar.
+
+### Front-end conventions (enforced by review, see `CONTRIBUTING.md`)
+
+- **No native dialogs.** Never use `window.confirm()`/`alert()`/`prompt()` — unreliable on Tauri 2. Use `tauri-prep/src/lib/modalConfirm.ts` (centered modal) or `inlineConfirm.ts` (inline strip).
+- **CSS namespacing is mandatory**: `prep-*`, `app-*`, `shell-*`. No unprefixed class names — the shell bundles prep + app CSS into one webview, so unprefixed classes collide.
+- `tauri-prep` lints with ESLint (`eslint.config.mjs`, includes `eslint-plugin-no-unsanitized`); use `lib/safeHtml.ts` rather than raw `innerHTML`.
+
+## Commits & versioning
+
+- **Conventional commits** with a component scope: `feat(prep):`, `fix(engine):`, `refactor(shell):`, `test(curation):`, `chore(release):`, `docs:`, `ci:`.
+- **Never hand-edit version numbers.** Run `python scripts/bump_version.py --engine X.Y.Z --shell X.Y.Z`, which syncs `pyproject.toml`, `src/multicorpus_engine/__init__.py`, and the shell's `tauri.conf.json` / `shell.ts` / `package.json`. (Note: `tauri-prep`/`tauri-app` carry their own independent versions — the docs are not always consistent here.)
+- Commit/push only when asked. Default PR branch is **`dev`** (some docs still say `development` — `dev` is what the repo uses).
+
+## Project conventions & gotchas
+
+- **`docs/DECISIONS.md`** (ADRs) and the audit docs (`docs/AUDIT_*.md`, `AUDIT_FOLLOW_UP.md`) are the authoritative design record. Design notes are frozen *before* a ticket is opened (e.g. `docs/DESIGN_sharedocs_ingestion.md`, the `TICKET_*` files).
+- **No new runtime dependencies in the sidecar bundle** without cause — the engine deliberately stays near stdlib (`python-docx`, `defusedxml`, `regex` only). New network/IO features use `urllib` + `defusedxml`, not `httpx`/`webdav4`.
+- **ShareDocs / WebDAV ingestion** (`remote/`, `docs/DESIGN_sharedocs_ingestion.md`): Phase 1 (CLI `import-remote`) is shipped; Phase 2 (sidecar routes) and Phase 3 (Prep UI) are not. The DB is never shared over WebDAV — this is ingestion-only.
+- **Curation regex**: `curation.py` uses the PyPI `regex` package with `regex.V0` forced (not stdlib `re`) for Unicode classes (`\p{L}`, `\X`, POSIX). Before changing the accepted-pattern grammar or migrating, run `python scripts/validate_regex_migration.py <corpus.db>` (exit 1 = human audit required).
+- **Git identity**: commit as `hsbtqemy <hugo.semilly@gmail.com>`. If `git config` is empty, restore it before committing rather than letting git derive a name from the OS account.
+- For deeper background read `CONTRIBUTING.md`, `HANDOFF_SHELL.md`/`HANDOFF_PREP.md` (front-end briefings), and `docs/SIDECAR_API_CONTRACT.md`.

--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -40,6 +40,7 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | D-04 | 🟡 | P1-7 | ✅ corrigé | **Ce fichier** (vue inverse finding→statut→commit) |
 | T-02 | 🟠 | P0-3 | ✅ corrigé | Suites dédiées `test_telemetry.py` (13) + `test_curation.py` (35) important le vrai code (étaient testés seulement indirectement). `curation.py` **100 %** ; coverage projet 61,94 %→66,82 %. PR #65 |
 | A-05 | — | — | ❌ retiré | Réfuté en passe 2 : les index secondaires existent (`003_alignment.sql`, `012_tokens.sql`) |
+| D-01 | 🟠 | P1-7 | ✅ corrigé | `ROADMAP.md` remis à niveau 2026-06-19 (forward roadmap ancrée sur cet audit + historique préservé + table phases étendue) ; `BACKLOG*.md` réconciliés — conventions CRUD F-1/F-2 (livré via onglet Rôles) et `POST /token_stats` SP-3.1 marqués ✅ avec preuve. Archivage CHANGELOG suivi séparément (D-02). |
 
 ### Ouverts
 
@@ -63,7 +64,6 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | U-03 | 🟡 | P2-11 | 🟦 partiel | `tauri-app` : 14 tests Vitest (happy-dom) sur le **vrai** `features/search.ts` (`buildFtsQuery`/`isSimpleInput`), gatés en CI (PR #60). Reste : couverture large des 8 112 l. (concordancier, état, rendu). |
 | U-04 | 🟡 | P2-12 | ⬜ ouvert | Signalisation de statut fragmentée entre READMEs |
 | U-05 | 🟡 | — | ⬜ ouvert | i18n absent (chaînes FR en dur) — non bloquant |
-| D-01 | 🟠 | P1-7 | ⬜ ouvert | ROADMAP/BACKLOG figés au 20-21 avril (dérive ~29 j) |
 | D-02 | 🟠 | P1-7 | ⬜ ouvert | CHANGELOG 1 942 lignes sans archivage |
 | D-03 | 🟠 | P2-10 | ⬜ ouvert | 267 artefacts trackés sans index (`audit/`, `artifacts/`) |
 | D-05 | 🟡 | P2-12 | ⬜ ouvert | Aucun guide utilisateur final |

--- a/docs/BACKLOG_PREP_AUDIT.md
+++ b/docs/BACKLOG_PREP_AUDIT.md
@@ -563,13 +563,15 @@ retour : {
 
 ---
 
-## Sprint F — Conventions (gestion UI + moteur)
+## Sprint F — Conventions (gestion UI + moteur) ✅ LIVRÉ
 
 > Indépendant des autres sprints. Prérequis fonctionnel pour l'usage réel des rôles de convention.
+>
+> **✅ Livré — réconciliation 2026-06-19 (finding D-01).** F-1 et F-2 ont été réalisés via l'onglet « Rôles » de la vue Segmentation (catalogue de rôles : CRUD créer/éditer/supprimer + couleurs/icônes), et non dans le panneau Curation initialement envisagé. Implémentation : `tauri-prep/src/components/RolesPane.ts` + helpers purs `lib/conventionsRoles.ts` ; `createConvention`/`updateConvention`/`deleteConvention` dans `sidecarClient.ts` ; endpoint `POST /conventions/update` livré côté sidecar. Spécs ci-dessous conservées pour trace.
 
 ---
 
-### F-1 — Interface de gestion des conventions (créer / supprimer)
+### F-1 — Interface de gestion des conventions (créer / supprimer) ✅ Livré (onglet Rôles)
 
 **Priorité :** Haute | **Effort :** M (3–5 h)
 **Fichiers :** `tauri-prep/src/screens/ActionsScreen.ts`, `tauri-prep/src/ui/app.css`
@@ -599,7 +601,7 @@ export async function deleteConvention(conn, name: string): Promise<{ deleted: s
 
 ---
 
-### F-2 — Modifier label, couleur, icône d'une convention (UPDATE)
+### F-2 — Modifier label, couleur, icône d'une convention (UPDATE) ✅ Livré (POST /conventions/update + onglet Rôles)
 
 **Priorité :** Moyenne | **Effort :** M (3–4 h)
 **Fichiers :** `src/multicorpus_engine/sidecar.py`, `tauri-prep/src/lib/sidecarClient.ts`, `tauri-prep/src/screens/ActionsScreen.ts`

--- a/docs/BACKLOG_RECHERCHE_GRAMMATICALE.md
+++ b/docs/BACKLOG_RECHERCHE_GRAMMATICALE.md
@@ -154,7 +154,9 @@ Réutiliser la palette UPOS et le rendu cellule déjà écrits dans `ActionsScre
 
 > Panneau latéral droit affichant les fréquences calculées sur les hits courants.
 
-### SP-3.1 — Backend `POST /token_stats`
+### SP-3.1 — Backend `POST /token_stats` ✅ Livré
+
+> **✅ Livré — réconciliation 2026-06-19 (finding D-01).** L'endpoint existe : `_handle_token_stats` ([sidecar.py:1758](../src/multicorpus_engine/sidecar.py#L1758), route enregistrée `sidecar.py:724`) délègue à `token_stats.run_token_stats` (`src/multicorpus_engine/token_stats.py`). Spéc ci-dessous conservée pour trace.
 
 **Fichier** : `src/multicorpus_engine/sidecar.py` + nouveau `token_stats.py`
 

--- a/docs/BACKLOG_ROLLBACK_CURATION.md
+++ b/docs/BACKLOG_ROLLBACK_CURATION.md
@@ -1,5 +1,14 @@
 # Backlog — Rollback partiel d'un apply de curation
 
+> **⚠️ Largement SUPERSEDED — réconciliation 2026-06-19 (finding D-01).**
+> Le cas d'usage principal de ce backlog (« annuler l'apply de curation qu'on vient de faire ») est **livré** par le **Mode A undo** : table `prep_action_history` + `prep_action_unit_snapshots` (migration `019_prep_action_history.sql`), exécuteur `src/multicorpus_engine/undo.py` (`compute_eligibility` / `execute_undo` → `_undo_curation_apply` avec restauration `text_norm`, re-flag des liens, `fts_stale`), endpoints `POST /prep/undo` + `/prep/undo/eligibility`, capture des snapshots via `curation.py` (`CurationActionRecorder`), et bouton **« ↺ Annuler »** dans `CurationView` (`prepUndo.ts`, testé). Le Mode A va même **au-delà** : il couvre aussi merge / split / resegment.
+>
+> **Reliquat réellement non livré = « Mode B » (rollback historique ciblé)** — le schéma de la migration 019 est explicitement prévu pour, sans changement : (1) annuler un apply *arbitraire* de l'historique (pas seulement le dernier — Mode A est strictement latest-only) ; (2) gardes d'éligibilité `structural_change` / `text_norm_diverged` (inutiles en latest-only) ; (3) UI par ligne dans le panneau « Historique des apply » (bouton + badge « annulé »). **Valeur plus faible, priorité basse.** Cf. `undo.py`, `migrations/019_prep_action_history.sql`.
+>
+> Les sections ci-dessous sont conservées pour trace ; ne les replanifier que pour le Mode B.
+
+---
+
 > Initiative issue de [HANDOFF_PREP.md § 7](../HANDOFF_PREP.md) « Réversibilité partielle ».
 > Objectif : permettre d'annuler une entrée `curate_apply_history` donnée et restaurer
 > les `text_norm` à leur état pré-apply, quand c'est encore cohérent.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,70 @@
 # Roadmap — multicorpus_engine
 
-Last updated: 2026-04-21 (v0.1.33 — audit sécurité 33 findings + feat #39 segments adjacents + hub hiérarchie)
+> **Dernière mise à jour : 2026-06-19** — remise à niveau post-audit (`docs/AUDIT_2026-06-12.md`), qui clôt le finding **D-01** (« ROADMAP/BACKLOG figés au 20-21 avril »). Suivi fin finding→statut→commit : **`docs/AUDIT_FOLLOW_UP.md`** ; idées produit détaillées : **`docs/BACKLOG*.md`** ; chantiers cadrés : `TICKET_*`/`DESIGN_*`. L'historique des incréments livrés est conservé plus bas (§ Historique).
 
-## Current state (implemented)
+## État au 2026-06-19
+
+Moteur jugé **techniquement sain et bien gouverné** par l'audit du 12 juin (notes B+/A- ; 1 seul finding réfuté sur 23). Les trois P0 de l'audit sont **traités ou volontairement arrêtés** : filet CI relevé (lint + couverture + dependabot), correctifs métier livrés, et l'extraction du monolithe `sidecar.py` (A-01) menée jusqu'à un point d'arrêt assumé (7 services). Restent surtout des chantiers **P1/P2** (pilotage, sécurité mineure, dette front) et deux chantiers produit vivants : l'unification du client sidecar (U-01) et l'ingestion ShareDocs/WebDAV.
+
+> **Note (passe de vérification code, 2026-06-19).** Une revue item-par-item des 6 `BACKLOG*.md` confrontés au code a montré qu'ils étaient **fortement périmés** : la quasi-totalité des items « ouverts » sont en réalité livrés. La liste « à venir » ci-dessous est donc recalée sur l'**état réel du code**, pas sur les statuts déclarés des backlogs (détail en § Réconciliation backlogs).
+
+## Réalisé depuis v0.2.6 / audit 2026-06-12
+
+- **A-01 — extraction services sidecar** (point d'arrêt assumé 2026-06-18) : 7 domaines sortis en `services/` (`import`, `conventions`, `doc_relations`, `documents`, `curate`, `units`, `tokens`) ; handlers→adaptateurs fins ; `sidecar.py` 9961→8523 l.
+- **Filet CI relevé** (P0-2) : `[tool.ruff]` + job lint (Q-01) ; gate couverture `--cov-fail-under=60` (T-01) ; dependabot étendu npm/pip/cargo (N-01) ; 394+ tests Vitest front enfin gatés en CI ; vite 5→8 (solde DEP-1).
+- **Tests cœur** (T-02) : suites directes `telemetry.py` + `curation.py` (100 %).
+- **Correctifs métier** (P1-5) : re-flag des liens undo merge/split/resegment (N-02), `links_created` via rowcount (N-03), `bump_version.py` → Cargo.toml shell (N-07), race statut job documentée (N-05).
+- **WebDAV/ShareDocs — Phase 1** : sous-commande CLI `import-remote` (client stdlib, dédup, dispatch unifié). P2/P3 à venir.
+- **S-03 (partiel)** : sink `setHtml`/`safeHtml` + ESLint no-unsanitized (3 fichiers prep).
+- **Pilotage** : `AUDIT_FOLLOW_UP.md` créé (D-04) ; ce rafraîchissement (D-01).
+
+## En cours
+
+- **U-01 — unification du client sidecar** (branche `refactor/u01-prep-canonical`, audit P1-4) : `sidecarClient.ts` app/prep, divergence ramenée 25→2 (PR1a/PR1b/PR2a) + tests d'intégration connexion/transport (T-05 partiel). Reste **PR2b** (l'app adopte le sous-système connexion de prep, byte-identique → divergence 2→0) puis **PR2c** (extraction `shared/` → un seul chunk client dans le shell).
+
+## Court terme (prochaines tranches)
+
+- **★ Export ODT** (priorité) : l'import ODT existe, l'export non (`exporters/readable_text.py` ne gère que `{txt, docx}`). Ajouter `export_readable_odt` pour rétablir la symétrie import/export. Vérifié absent du code.
+- **★ Dette doc — cadrages manquants** (priorité) : écrire `docs/cadrage/METADONNEES_DOCUMENT.md` (D1 — la validation `/validate-meta` est livrée, seule la note de cadrage manque) et `docs/cadrage/IMPORT_RATIO.md` (D2 — décision + calibration du seuil de ratio d'import ; à ce jour ni logique ni doc).
+- **WebDAV/ShareDocs P2 — endpoints sidecar** (`POST /webdav/list`, `POST /import-remote`) puis **P3 — UI Prep**. P2 débloqué (le dispatch dont il dépendait est déjà unifié) ; **P3 à séquencer après U-01** (touche `sidecarClient.ts`). Réf. `DESIGN_sharedocs_ingestion.md`, tickets P2/P3.
+- **Sécurité mineure** (P1-8, ~½ j) : validation `Host`/`Origin` (S-01), portfile `O_CREAT|O_EXCL|0o600` (S-02), `defusedxml` dans `exporters/tei.py` (S-04).
+- **S-03 — décision XSS lint** (P0-2 résiduel) : trancher grind complet (92 sites des 4 écrans géants + app/shell) vs suppressions ciblées, puis job ESLint bloquant.
+- **Pilotage** (P1-7) : archivage du CHANGELOG (D-02, 1 942 l.) ; documenter `API_VERSION` vs `CONTRACT_VERSION` (D-06).
+- **Tests** (P1-6) : isoler les 11 fichiers versionnés sous `tests/contracts/` (T-03).
+
+## Moyen / long terme
+
+- **Rollback curation — superseded** : le cas « annuler l'apply qu'on vient de faire » est livré (Mode A undo : `prep_action_history`/migration 019, `undo.py`, `POST /prep/undo`, bouton « ↺ Annuler » dans CurationView), et couvre même merge/split/resegment. Reliquat **non livré, priorité basse** = « Mode B » (rollback d'un apply *arbitraire* de l'historique + gardes `structural_change`/`text_norm_diverged` + UI par ligne) ; schéma déjà prêt. Cf. `BACKLOG_ROLLBACK_CURATION.md`.
+- **Analytics Concordancier — reste la distribution temporelle** : phase 1 (tri KWIC + dispersion) et collocations (`/token_collocates`) **livrées** ; seul manque le `group_by` année/`doc_date` dans `token_stats` (F2 phase 2).
+- **Dette front** : `CurationView`/`SegmentationView`/`AnnotationView` **déjà extraits** d'`ActionsScreen` (U-02 partiel) ; les vues résultantes restent volumineuses (Curation/Metadata) → découpe au fil de l'eau. Couverture Vitest large `tauri-app` (U-03) ; render-smoke DOM différés (T-05).
+- **Finitions & décisions UX (mineur)** : coloration syntaxique du champ CQL (seule vraie feature CQL non livrée, effort faible) ; SP-2.1 — navigation pivot→Prep **actée comme voulue** (cohérent avec F3), éventuel +deep-link Explorer optionnel ; D3 — harmoniser le badge « Source modifiée » dans le concordancier shell (optionnel).
+- **Typage** : TypedDict pour les shapes de contrat (Q-04), attributs `HTTPServer` typés (A-04), mypy progressif (exclure sidecar.py au début) ; cap global documenté du matcher CQL (Q-05).
+- **Pilotage/doc** : index des ~267 artefacts trackés (D-03) ; guide utilisateur final (D-05) ; bandeau de statut `tauri-app/README` (U-04).
+- **Dette assumée à arbitrer en ADR** : resegmentation écrase `text_raw` + supprime les liens (N-04).
+- **Divers** : lockfiles + `npm ci` pour `tauri-fixture` (N-06) ; fragilités timing des tests sidecar (T-04, 23 `time.sleep`) ; i18n (U-05, non bloquant).
+- **Shell P9** : multi-fenêtre (Explorer + Constituer), hot-swap DB sans redémarrage sidecar, dépréciation des apps standalone `tauri-app`/`tauri-prep`.
+- **Distribution / supply chain** : AppImage Linux PKG-3C ; signing prod (cert Apple Developer + PFX en Secrets, scripts/workflows prêts) ; épinglage GitHub Actions par SHA (F-03).
+- **Moteur (horizon)** : stratégie d'indexation incrémentale au-delà du rebuild ; packs de segmentation par langue enrichis ; workspace multi-projets + commandes de maintenance corpus ; extensions de profil TEI (ancres, apparat, métadonnées riches).
+
+## Parqué — décision assumée (ne pas replanifier)
+
+- **A-01 — poursuite de l'extraction sidecar** : arrêt volontaire. Les domaines à logique DB réelle sont sortis ; restent des délégateurs (`export`/`query`/`token_query`/`stats` — logique déjà ailleurs) et des handlers à état/couplés (`units/merge`+`split`, `curate_preview`/`*_export`, `align`/`segment`/`jobs`). Réf. `AUDIT_FOLLOW_UP.md`.
+
+## Réconciliation backlogs (passe de vérification code, 2026-06-19)
+
+Vérification item-par-item des 6 `BACKLOG*.md` contre le code : ils étaient **fortement périmés**, la quasi-totalité des items « ouverts » sont livrés. Re-balisés `✅ Livré` / superseded dans les fichiers concernés lors de cette passe :
+
+- **Conventions — CRUD UI** (`BACKLOG_PREP_AUDIT.md` F-1/F-2) : livré via l'onglet « Rôles » (`components/RolesPane.ts` ; `create/update/deleteConvention`).
+- **`POST /token_stats`** (`BACKLOG_RECHERCHE_GRAMMATICALE.md` SP-3.1) : livré (`_handle_token_stats` → `token_stats.run_token_stats`).
+- **Rollback curation** (`BACKLOG_ROLLBACK_CURATION.md`) : bandeau « superseded par Mode A undo » + reliquat Mode B (cf. Moyen/long terme).
+
+Également **confirmés livrés** par la passe mais **pas encore re-balisés ligne à ligne** dans `BACKLOG.md` (nettoyage cosmétique restant) : quick-wins Q1-Q4, UX U1-U3, décisions D1/D4/D5, features F1/F3/F5, toute la couche tokens/annotation/POS/CoNLL-U, recherche fédérée multi-DB (Model C), export TMX/bilingue, namespacing CSS E-1. Genuinement ouverts (vérifiés absents) : Export ODT, cadrages D1/D2, distribution temporelle (F2 ph.2), coloration CQL, Shell P9 (multi-fenêtre / hot-swap DB / dépréciation standalone).
+
+---
+
+## Historique
+
+### Current state (implemented)
 
 - Core DB + migrations + run logging are in place and idempotent.
 - Importers implemented: `docx_numbered_lines`, `txt_numbered_lines`, `docx_paragraphs`, `tei`.
@@ -59,7 +121,7 @@ Last updated: 2026-04-21 (v0.1.33 — audit sécurité 33 findings + feat #39 se
   - async jobs `kind=index` with `params.incremental`
   - design note `docs/INCREMENTAL_INDEXING.md`
 
-## Now (v0.6.1 → tauri-prep)
+### Détail des incréments livrés (Prep, Concordancier, Shell)
 
 - All core engine increments done (V1.0–V2.8): importers, query, alignment, exports, sidecar, packaging.
 - **Tauri UI "Concordancier" V0** done: search-first desktop app (`tauri-app/`), V0.1 aligned view, V0.2 pagination.
@@ -110,24 +172,9 @@ Last updated: 2026-04-21 (v0.1.33 — audit sécurité 33 findings + feat #39 se
 - Keep sidecar optional and non-blocking for CLI-first workflows.
 - Maintain deterministic, lightweight regression tests (no heavy corpus fixtures).
 
-## Next
+> Les anciennes sections « Next » / « Later » (avril) ont été refondues dans la roadmap à venir, en tête de fichier. Items reportés tels quels : AppImage PKG-3C, signing prod, F-03 SHA pinning, multi-fenêtre, indexation incrémentale avancée, packs de segmentation enrichis, workspace multi-projets, extensions de profil TEI.
 
-- **CI stabilisation** : Linux AppImage PKG-3C (requires Linux runner).
-- **Shell V0.x roadmap** : style dedup inter-modules, shared db-path, multi-window.
-- **Signing prod** : macOS notarization + Windows signtool nécessitent un certificat Apple Developer / PFX réel configuré en GitHub Secrets. Scripts et workflows prêts.
-- **F-03 GitHub Actions** : épinglage des actions par SHA (supply chain hardening) — non traité (F-04 permissions ✅, F-03 SHA pinning encore ouvert).
-- Performance : monitor startup/size trade-offs over future benchmark refreshes.
-
-> **Réalisé (ne pas replanifier ici)** : audit sécurité 33 findings (v0.1.31) ✅ ; feat #39 segments adjacents ✅ ; hub hiérarchie Actions ✅ ; About dialog contract_version ✅ ; panneau métadonnées hit/document ; corpus démo first-run ; PKG-1→PKG-3A packaging (macOS .dmg ✅, Windows NSIS ✅) ; CI hardening. Détail : `docs/BACKLOG.md` + `docs/AUDIT_2026-04-19.md`.
-
-## Later
-
-- Incremental indexing strategy (beyond full rebuild) with correctness guarantees and explicit flags.
-- Richer segmentation quality by language (additional packs + evaluation fixtures and quality metrics).
-- Multi-project workspace/registry and corpus-level maintenance commands.
-- TEI import/export profile extensions (anchors, apparatus, richer metadata mapping).
-
-## Phases
+### Phases — incréments livrés
 
 | Phase | Scope | Status |
 |-------|-------|--------|
@@ -177,3 +224,9 @@ Last updated: 2026-04-21 (v0.1.33 — audit sécurité 33 findings + feat #39 se
 | V2.0.1 | feat #39 : segments adjacents opt-in dans recherche grammaticale (v0.1.31) | Done |
 | V2.0.2 | Hub Actions : vue hiérarchie documents (v0.1.33) | Done |
 | V2.0.3 | About dialog : contract_version live depuis /health (v0.1.32/33) | Done |
+| V2.1.0 | Audit 2026-06-12 : filet CI (ruff + couverture 60 % + dependabot) + tests cœur (Q-01/T-01/N-01/T-02) | Done |
+| V2.1.1 | A-01 : extraction de 7 services sidecar (point d'arrêt assumé, sidecar.py 9961→8523 l.) | Done |
+| V2.1.2 | Correctifs métier audit : undo reflag, links_created via rowcount, bump Cargo.toml (N-02/N-03/N-07) | Done |
+| V2.1.3 | WebDAV/ShareDocs Phase 1 : CLI `import-remote` (stdlib, dédup, dispatch unifié) | Done |
+| V2.1.4 | U-01 : sidecarClient app/prep — divergence 25→2 (PR1a/1b/2a) + tests connexion/transport | En cours |
+| D-01 | Pilotage : ROADMAP/BACKLOG remis à niveau post-audit + AUDIT_FOLLOW_UP.md (D-04) | Done |


### PR DESCRIPTION
## Pourquoi

L'audit `AUDIT_2026-06-12.md` relevait le finding **D-01** : ROADMAP/BACKLOG figés au 20-21 avril, items « Now » déjà livrés. Cette PR remet le pilotage au niveau du code et, au passage, **réconcilie les backlogs vérifiés item-par-item contre le code réel** (pas contre leurs statuts déclarés).

## Contenu

**`docs/ROADMAP.md`** — rafraîchie :
- Forward roadmap ancrée sur l'audit (P0/P1/P2) en tête ; historique préservé (§ Historique) ; table des phases étendue (V2.1.x).
- Recalée sur l'état **vérifié** du code après une passe de vérification (4 agents, item-par-item).

**Réconciliation backlogs** (trace conservée, specs gardées) :
- `BACKLOG_PREP_AUDIT.md` — conventions CRUD **F-1/F-2** marqués livré (onglet « Rôles », `RolesPane.ts`, `create/update/deleteConvention`).
- `BACKLOG_RECHERCHE_GRAMMATICALE.md` — **SP-3.1 `POST /token_stats`** marqué livré (`_handle_token_stats` → `token_stats.run_token_stats`).
- `BACKLOG_ROLLBACK_CURATION.md` — bandeau **« superseded par Mode A undo »** (`prep_action_history`/migration 019, `undo.py`, `POST /prep/undo`) ; reliquat = **Mode B** (rollback historique ciblé, schema-ready, P-basse).
- `AUDIT_FOLLOW_UP.md` — **D-01** déplacé en « corrigé ».

**`CLAUDE.md`** (nouveau) — guide d'orientation du dépôt pour Claude Code (commandes, gates CI dont le sidecar growth-gate, archi des deux couches, protocole d'ajout d'endpoint, conventions front, statut WebDAV).

## Finding clé de la passe

Les `BACKLOG*.md` étaient **fortement périmés** : la quasi-totalité des items « ouverts » sont en réalité livrés (Q1-Q4, U1-U3, D1/D4/D5, F1/F3/F5, couche tokens/annotation/POS/CoNLL-U, recherche fédérée multi-DB, export TMX/bilingue, conventions, namespacing CSS E-1).

**Réellement ouvert (vérifié absent du code)** : Export ODT, cadrages D1/D2, distribution temporelle (F2 ph.2), coloration CQL, Shell P9 (multi-fenêtre / hot-swap DB / dépréciation standalone).

## Portée

Docs/pilotage uniquement — **aucun changement de code**. Le nettoyage cosmétique ligne-à-ligne de `BACKLOG.md` (re-balisage des items confirmés livrés) reste à faire dans une passe ultérieure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
