### PR TITLE
fix(prep): modalConfirm _esc échappe le guillemet double (parité S-03)

### DIFF
--- a/tauri-prep/src/lib/modalConfirm.ts
+++ b/tauri-prep/src/lib/modalConfirm.ts
@@ -17,8 +17,11 @@
 
 import { safeHtml, raw, setHtml } from "./safeHtml.ts";
 
+// Escapes & < > " — parity with the other prep escapers (S-03). modalConfirm
+// renders title/message in text context today, but " is escaped too so this
+// shared primitive stays attribute-safe if its template ever changes.
 function _esc(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 export function modalConfirm(opts: {


### PR DESCRIPTION
## Durcissement escaper `modalConfirm` (passe de revue S-03)

Issu de la passe de revue post-burndown S-03 (#86 app, #87 shell) : vérification que les patterns corrigés (escaper sans `"`, `raw()` vouchant de la donnée non échappée) n'existaient pas en trou actif dans le code prep déjà mergé.

- **Aucun trou actif** dans prep : tous les escapers utilisés en contexte d'attribut échappent `"` (`_escHtml` par écran, `_escHtmlApp` / `_escHtmlMeta`, AlignPanel, RolesPane, Segmentation, JobCenter, Annotation) ; les badges de rôle pré-échappent leur `label`.
- **Une seule nit de parité** : `modalConfirm._esc` était le dernier escaper whitelisté de prep à n'échapper que `& < >`. Usage actuel **texte uniquement** (donc pas de trou), mais c'est une primitive UI partagée → durci à `& < > "` pour rester sûr en contexte d'attribut si son template évolue.

`sidecarClient._esc` est **laissé tel quel** : interne à `richTextToHtml`, délibérément calé sur l'échappement XML de l'importeur (`& < >`), texte seul — le durcir serait inutile (contexte texte) et désynchroniserait l'invariant documenté.

### Vérification
- `npm run lint` (no-unsanitized) — **0**
- `npm run build` (tsc + vite) — OK
- vitest — **422/422**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
