### PR TITLE
docs: clarifie le versioning du contrat sidecar (D-06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **docs / versioning du contrat sidecar (D-06)** : section *Versioning* de [`docs/SIDECAR_API_CONTRACT.md`](docs/SIDECAR_API_CONTRACT.md) réécrite — elle confondait `api_version` avec la version du contrat et donnait des valeurs fausses (`api_version: "1.6.27"`, `version: "0.8.2"`). Clarifié en 3 champs distincts : `api_version` (= `API_VERSION`, version d'implémentation runtime), `version` (= `API_VERSION` dans l'enveloppe, mais **version moteur** sur `/health`), et `contract_version` (= `CONTRACT_VERSION`, **source de vérité** du contrat, gelée en CI). Exemples corrigés pour refléter ce que le code émet réellement. Dérive signalée (`API_VERSION` 1.6.23 < `CONTRACT_VERSION` 1.6.27, bumps 1.6.24–1.6.27 oubliés) → réconciliation code laissée à un ticket séparé. Docs-only.
 - **docs / archivage du CHANGELOG (D-02)** : le CHANGELOG (1 951 l.) est scindé — le courant garde `[Unreleased]` + les releases semver ([0.1.12]→[0.2.6], 557 l.) ; l'historique antérieur (schéma de versions « V… » V0→V1.9 et incréments [0.1.0]→[0.6.1]) est déplacé dans [`docs/CHANGELOG_ARCHIVE.md`](docs/CHANGELOG_ARCHIVE.md) avec un pointeur. Intégrité vérifiée (82 sections, 0 perdue).
 
 ### Fixed

--- a/docs/AUDIT_FOLLOW_UP.md
+++ b/docs/AUDIT_FOLLOW_UP.md
@@ -67,7 +67,7 @@ le §6 de l'audit 2026-06-12 ; « — » = non priorisé explicitement.
 | D-02 | 🟠 | P1-7 | ✅ corrigé | CHANGELOG scindé : courant **1951→557 l.** (`[Unreleased]` + semver [0.1.12]→[0.2.6]) ; l'historique antérieur (schéma « V… » + incréments [0.1.0]→[0.6.1]) déplacé dans **`docs/CHANGELOG_ARCHIVE.md`** (1406 l.) + pointeur. Intégrité vérifiée (82 sections = 35 + 47, 0 perdue). |
 | D-03 | 🟠 | P2-10 | ⬜ ouvert | 267 artefacts trackés sans index (`audit/`, `artifacts/`) |
 | D-05 | 🟡 | P2-12 | ⬜ ouvert | Aucun guide utilisateur final |
-| D-06 | 🟡 | P1-7 | ⬜ ouvert | `API_VERSION` (1.6.23) vs `CONTRACT_VERSION` (1.6.27) — distinction non documentée |
+| D-06 | 🟡 | P1-7 | ✅ documenté | Section *Versioning* de `docs/SIDECAR_API_CONTRACT.md` réécrite : 3 champs distincts (`api_version`=`API_VERSION` impl runtime ; `version` envelope=`API_VERSION`, mais engine version sur `/health` ; `contract_version`=`CONTRACT_VERSION`, source de vérité du contrat). Exemples d'enveloppe corrigés (disaient `1.6.27`/`0.8.2`, le code émet `API_VERSION`). **Dérive signalée** : `API_VERSION` 1.6.23 < `CONTRACT_VERSION` 1.6.27 (bumps 1.6.24–1.6.27 oubliés) → réconciliation code = ticket séparé (touche l'enveloppe ⇒ contract-freeze). |
 | N-04 | 🟡 | P2-14 | 🔵 connu/assumé | Resegmentation écrase `text_raw` + supprime les liens (dette HANDOFF) ; à arbitrer en ADR |
 | N-06 | 🟡 | P2-9 | ⬜ ouvert | `tauri-fixture` sans lockfiles ; CI en `npm install` |
 | N-08 | 🟢 | — | ⬜ ouvert | Divers mineurs (sémantique reflag cible, lock télémétrie Windows, release-gate 3.12, etc.) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,7 +30,7 @@ Moteur jugé **techniquement sain et bien gouverné** par l'audit du 12 juin (no
 - **WebDAV/ShareDocs P2 — endpoints sidecar** (`POST /webdav/list`, `POST /import-remote`) puis **P3 — UI Prep**. P2 débloqué (le dispatch dont il dépendait est déjà unifié) ; **P3 désormais débloqué** aussi (touche `sidecarClient.ts`, qui n'évolue plus depuis la clôture d'U-01). Réf. `DESIGN_sharedocs_ingestion.md`, tickets P2/P3.
 - ~~**Sécurité mineure** (P1-8)~~ **✅ fait** : garde `Host` loopback / DNS-rebinding (S-01), portfile `O_EXCL|0o600` (S-02), `exporters/tei.py` confirmé write-only (S-04, pas de surface XXE).
 - ~~**S-03 — burndown XSS lint**~~ **✅ CLOS** (#80→#88) : prep (phase 1 + 4 géants, baseline 89→0) **+ phase 2** `tauri-app` (#86) & `tauri-shell` (#87) + fix prep #88. Les 3 front-ends ont une garde `no-unsanitized` stricte en CI, aucune baseline. Voir `docs/TICKET_S03_PHASE2_APP_SHELL.md`.
-- **Pilotage** (P1-7) : ~~archivage du CHANGELOG (D-02)~~ **✅ fait** (scindé → `docs/CHANGELOG_ARCHIVE.md`) ; reste : documenter `API_VERSION` vs `CONTRACT_VERSION` (D-06).
+- ~~**Pilotage** (P1-7)~~ **✅ fait** : ~~archivage du CHANGELOG (D-02)~~ (scindé → `docs/CHANGELOG_ARCHIVE.md`) ; ~~documenter `API_VERSION` vs `CONTRACT_VERSION` (D-06)~~ (section *Versioning* de `SIDECAR_API_CONTRACT.md` réécrite + dérive 1.6.23/1.6.27 signalée).
 - **Tests** (P1-6) : isoler les 11 fichiers versionnés sous `tests/contracts/` (T-03).
 
 ## Moyen / long terme

--- a/docs/SIDECAR_API_CONTRACT.md
+++ b/docs/SIDECAR_API_CONTRACT.md
@@ -29,8 +29,24 @@ When `multicorpus serve` starts and a portfile already exists:
 
 ## Versioning
 
-- `api_version`: sidecar API contract version (`1.6.27`)
-- `version`: engine version
+Three **independent** version fields surface in sidecar responses — do not conflate them
+(all but the engine version are defined in `sidecar_contract.py`):
+
+| Field | Backed by | Meaning | Where it appears |
+|---|---|---|---|
+| `api_version` | `API_VERSION` | Runtime version of the sidecar **API implementation**. | every response envelope; `/openapi.json` → `info.version`; TMX export provenance |
+| `version` (envelope) | `API_VERSION` | In the **generic envelope**, identical to `api_version`. **Exception:** on `/health` it is overridden with the **engine package version** (`ENGINE_VERSION` = `multicorpus_engine.__version__`). | response envelope; `/health` (engine version) |
+| `contract_version` / `x-contract-version` | `CONTRACT_VERSION` | Semver of the **API contract surface** (endpoints + payload shapes). Bumped on any contract change, enforced by the contract-freeze CI gate, and carries a per-version changelog in `sidecar_contract.py`. | `/health` (`contract_version`); `/openapi.json` (`x-contract-version`); TEI package provenance |
+
+**Source of truth for "which contract does this build speak" = `CONTRACT_VERSION`.**
+
+> ⚠️ **Known drift (D-06).** `API_VERSION` (`1.6.23`) lags `CONTRACT_VERSION` (`1.6.27`):
+> the `API_VERSION` bump was skipped for the contract changes 1.6.24–1.6.27. The two
+> share a numbering scheme and were historically bumped together. Until reconciled, rely
+> on `CONTRACT_VERSION` for contract identity; `api_version` is the loosely-maintained
+> implementation version. Reconciliation options (separate ticket — touches the response
+> envelope ⇒ requires `export_openapi.py` regen + contract-freeze): bump both in lockstep,
+> or derive `api_version` from `CONTRACT_VERSION` (single source).
 
 ## Response envelope
 
@@ -39,8 +55,8 @@ When `multicorpus serve` starts and a portfile already exists:
 ```json
 {
   "ok": true,
-  "api_version": "1.6.27",
-  "version": "0.8.2",
+  "api_version": "1.6.23",
+  "version": "1.6.23",
   "status": "ok"
 }
 ```
@@ -50,8 +66,8 @@ When `multicorpus serve` starts and a portfile already exists:
 ```json
 {
   "ok": false,
-  "api_version": "1.6.27",
-  "version": "0.8.2",
+  "api_version": "1.6.23",
+  "version": "1.6.23",
   "status": "error",
   "error": {
     "type": "VALIDATION_ERROR",


### PR DESCRIPTION
## docs — clarifie le versioning du contrat sidecar (D-06)

Quick win post-S-03. La section *Versioning* de `docs/SIDECAR_API_CONTRACT.md` **confondait** `api_version` avec la version du contrat et donnait des **valeurs fausses** (`api_version: "1.6.27"`, `version: "0.8.2"` — le code émet en réalité `API_VERSION` = `1.6.23`).

### Réécriture — 3 champs distincts
| Champ | Backed by | Sens |
|---|---|---|
| `api_version` | `API_VERSION` | version d'**implémentation runtime** (enveloppe, `openapi info.version`, provenance TMX) |
| `version` (enveloppe) | `API_VERSION` | idem `api_version` dans l'enveloppe générique ; **écrasé par la version moteur** (`ENGINE_VERSION`) sur `/health` |
| `contract_version` / `x-contract-version` | `CONTRACT_VERSION` | **source de vérité** du contrat (surface endpoints/shapes), gelée par le contract-freeze CI, changelog inline |

Exemples d'enveloppe corrigés pour refléter ce que le code émet.

### ⚠️ Dérive signalée (laissée à un ticket séparé)
`API_VERSION` (`1.6.23`) **retarde** sur `CONTRACT_VERSION` (`1.6.27`) — les bumps 1.6.24→1.6.27 n'ont pas été répercutés sur `API_VERSION`. Réconciliation = changement de code touchant l'enveloppe ⇒ regen `openapi.json` + contract-freeze, donc hors de cette PR docs-only. Documenté comme dette.

Statuts D-06 mis à jour (`AUDIT_FOLLOW_UP` ✅ documenté, `ROADMAP` Pilotage clos), entrée CHANGELOG.

**Docs-only, aucun changement de code.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
