### PR TITLE
docs(tests): corrige 3 refs de chemin post-T-03

### DIFF
--- a/tests/services/test_doc_relations_service.py
+++ b/tests/services/test_doc_relations_service.py
@@ -1,7 +1,7 @@
 """Direct unit tests for the doc_relations service (audit P0-1 / A-01).
 
 Exercises the extracted doc_relations CRUD without any HTTP server. The sidecar
-HTTP adapters are covered end-to-end by tests/test_sidecar_v04.py (set/get/delete)
+HTTP adapters are covered end-to-end by tests/contracts/test_sidecar_v04.py (set/get/delete)
 and the binary smoke (/doc_relations/all) in CI.
 """
 

--- a/tests/services/test_documents_service.py
+++ b/tests/services/test_documents_service.py
@@ -3,7 +3,7 @@
 Exercises the extracted documents CRUD without any HTTP server. The migrated
 schema already has the workflow columns + tokens table, so list_documents works
 without the adapter's legacy backfill. HTTP adapters stay covered by
-tests/test_sidecar_v04.py / test_sidecar_api_contract.py + the binary smoke
+tests/contracts/test_sidecar_v04.py / test_sidecar_api_contract.py + the binary smoke
 (GET /documents).
 """
 

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -1,6 +1,6 @@
 """Direct unit tests for curation.py (audit T-02).
 
-`rules_from_list` had some coverage in test_v21.py; the rest of the engine did
+`rules_from_list` had some coverage in tests/contracts/test_v21.py; the rest of the engine did
 not. These tests cover the pure helpers (ReDoS/length guard, JS→Python
 replacement translation, apply_rules) and — the real core — curate_document's
 5-level priority logic, paratextual exclusion, the Mode-A undo recorder


### PR DESCRIPTION
Suite à T-03 (#91), 3 docstrings de couverture citaient encore les anciens chemins de tests. Repointées vers `tests/contracts/`.

- `test_documents_service.py` / `test_doc_relations_service.py` → `tests/contracts/test_sidecar_v04.py`
- `test_curation.py` → `tests/contracts/test_v21.py`

Commentaires uniquement, aucun changement de code. `ruff check` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)