### PR TITLE
feat(engine): migration units_service — coerce-int id checks (A-03 lot 3)

### DIFF
--- a/src/multicorpus_engine/services/units_service.py
+++ b/src/multicorpus_engine/services/units_service.py
@@ -16,6 +16,7 @@ import sqlite3
 from typing import Any, Optional
 
 from .errors import BadRequestError, NotFoundError
+from .validation import Field, validate
 
 
 def _role_exists(conn: sqlite3.Connection, role: str) -> bool:
@@ -56,21 +57,21 @@ def list_units(
     return {"units": units, "count": len(units), "doc_id": doc_id}
 
 
+_SET_ROLE_SCHEMA = (
+    Field("doc_id", int, coerce=True, error=BadRequestError),
+    Field("unit_n", int, coerce=True, error=BadRequestError),
+)
+
+
 def set_unit_role(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
     """Assign (or clear) a convention role on one unit (POST /units/set_role).
 
     Raises BadRequestError (missing/non-int ids) or NotFoundError (role or unit).
     """
-    doc_id = body.get("doc_id")
-    unit_n_raw = body.get("unit_n")
+    ids = validate(body, _SET_ROLE_SCHEMA)
+    doc_id = ids["doc_id"]
+    unit_n = ids["unit_n"]
     role = body.get("role")  # None or "" -> clear
-    if doc_id is None or unit_n_raw is None:
-        raise BadRequestError("doc_id and unit_n are required")
-    try:
-        doc_id = int(doc_id)
-        unit_n = int(unit_n_raw)
-    except (TypeError, ValueError):
-        raise BadRequestError("doc_id and unit_n must be integers")
 
     role = (role or "").strip() or None  # normalise empty string -> None
 
@@ -144,6 +145,9 @@ def bulk_set_unit_role(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
     return {"updated": result.rowcount}
 
 
+_UPDATE_TEXT_SCHEMA = (Field("unit_id", int, coerce=True, error=BadRequestError),)
+
+
 def update_unit_text(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
     """Update text_raw and/or text_norm for one unit (POST /units/update_text).
 
@@ -151,13 +155,7 @@ def update_unit_text(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
     is mirrored to text_norm. Reindexes FTS (best-effort). Raises BadRequestError
     or NotFoundError (unknown unit_id).
     """
-    unit_id_raw = body.get("unit_id")
-    if unit_id_raw is None:
-        raise BadRequestError("unit_id is required")
-    try:
-        unit_id = int(unit_id_raw)
-    except (TypeError, ValueError):
-        raise BadRequestError("unit_id must be an integer")
+    unit_id = validate(body, _UPDATE_TEXT_SCHEMA)["unit_id"]
 
     text_raw = body.get("text_raw")
     text_norm = body.get("text_norm")


### PR DESCRIPTION
## A-03 lot 3 — `units_service` (checks coerce-int)

Troisième lot. Sur le socle #94 (mergé), **indépendant de #95** (n'utilise que `coerce`, ne touche pas `validation.py`). Établit le pattern le plus récurrent du sidecar : **id required + must be integer** (`int(raw)` → `Field(int, coerce=True)`), voie `BadRequestError`.

### Migré (coerce-int id checks)
| Fonction | Schéma |
|---|---|
| `set_unit_role` | `doc_id` + `unit_n` — `Field(int, coerce=True, error=BadRequestError)` |
| `update_unit_text` | `unit_id` — idem |

`error_code` byte-identique (`BadRequestError → ERR_BAD_REQUEST`). Les messages **combinés** cross-field (« doc_id and unit_n are required ») deviennent **per-field** (« doc_id is required ») — autorisé : messages non figés, les 20 tests service n'assertent que `pytest.raises`. **À reviewer si tu tiens au message combiné.**

### Laissé inline (hors périmètre per-champ — units est surtout NON-Field-able)
- `list_units` : `doc_id` est un **param query** (arg de fonction, pas `body`).
- `bulk_set_unit_role` : either/or (unit_ids XOR doc_id+unit_ns) + liste **coercée** (`[int(i) for i in …]`, ≠ `items` isinstance).
- `text_raw` / `text_norm` : optionnels **nullables** (null valide) → nécessitent l'option `Field` `nullable` (toujours en attente).
- « at least one text » (cross-field) + `NotFoundError` (sémantique).

### Vérification
- `ruff check src tests` — OK
- `pytest` — **60 passed** : `test_units_service.py` (20, byte-identique) + `test_validation.py` (40, intact)
- Net **−2 lignes** ; wire `/units/*` (subprocess) → CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
