### PR TITLE
feat(engine): valideur option nullable + migration tokens_service (A-03 lot 4)

### DIFF
--- a/src/multicorpus_engine/services/tokens_service.py
+++ b/src/multicorpus_engine/services/tokens_service.py
@@ -15,6 +15,7 @@ import sqlite3
 from typing import Any, Optional
 
 from .errors import BadRequestError, NotFoundError
+from .validation import Field, validate
 
 # Token projection shared by list + update (JOIN units for doc_id / unit_n / external_id).
 _TOKEN_SELECT = """
@@ -103,31 +104,21 @@ def list_tokens(
     }
 
 
+_TOKEN_UPDATE_SCHEMA = (
+    Field("token_id", int, coerce=True, min=1, error=BadRequestError),
+    *(Field(k, str, required=False, nullable=True, error=BadRequestError) for k in _TOKEN_UPDATABLE),
+)
+
+
 def update_token(conn: sqlite3.Connection, body: dict) -> dict[str, Any]:
     """Update annotation fields of one token (POST /tokens/update).
 
     Raises BadRequestError (bad token_id, non-string field, no fields) or
     NotFoundError (unknown token_id).
     """
-    token_id_raw = body.get("token_id")
-    if token_id_raw is None:
-        raise BadRequestError("token_id is required")
-    try:
-        token_id = int(token_id_raw)
-    except (TypeError, ValueError):
-        raise BadRequestError("token_id must be an integer")
-    if token_id <= 0:
-        raise BadRequestError("token_id must be a positive integer")
-
-    updates: dict[str, object] = {}
-    for key in _TOKEN_UPDATABLE:
-        if key not in body:
-            continue
-        value = body.get(key)
-        if value is None or isinstance(value, str):
-            updates[key] = value
-        else:
-            raise BadRequestError(f"{key} must be a string or null")
+    clean = validate(body, _TOKEN_UPDATE_SCHEMA)
+    token_id = clean["token_id"]
+    updates: dict[str, object] = {k: clean[k] for k in _TOKEN_UPDATABLE if k in clean}
     if not updates:
         raise BadRequestError(
             "No updatable token fields provided (allowed: word, lemma, upos, xpos, feats, misc)"

--- a/src/multicorpus_engine/services/validation.py
+++ b/src/multicorpus_engine/services/validation.py
@@ -67,6 +67,10 @@ class Field:
     default  value injected when the field is absent and not required.
     coerce   ``int(value)`` coercion; failure yields ``"<name> must be an integer"``.
     strip    strip ``str`` values (and, when ``required``, treat blank as missing).
+    nullable for an OPTIONAL field, a present ``null`` is valid and kept as
+             ``None`` (an absent key stays absent). Without it, a present ``null``
+             on an optional field is type-checked — i.e. rejected (the legacy
+             ``isinstance``-guard default).
     items    for a list / tuple, the required element type:
              ``"<name> must be a list of …s"``.
     error    typed error class to raise (``ValidationError`` or ``BadRequestError``).
@@ -81,6 +85,7 @@ class Field:
     default: Any = _UNSET
     coerce: bool = False
     strip: bool = False
+    nullable: bool = False
     items: type | tuple[type, ...] | None = None
     error: type[ServiceError] = ValidationError
 
@@ -122,8 +127,13 @@ def validate(
             continue
 
         value = body.get(f.name)
-        if value is None and f.required:
-            raise f.error(f"{f.name} is required")
+        if value is None:
+            if f.required:
+                raise f.error(f"{f.name} is required")
+            if f.nullable:
+                out[f.name] = None
+                continue
+            # optional + non-nullable: fall through so the type check rejects null.
 
         if f.strip and isinstance(value, str):
             value = value.strip()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -55,6 +55,46 @@ def test_optional_present_null_is_type_checked():
     assert e.value.message == "incremental must be a boolean"
 
 
+# ─── nullable (optional field where null is valid) ────────────────────────────
+
+def test_nullable_present_null_kept():
+    assert validate({"x": None}, (Field("x", str, required=False, nullable=True),)) == {"x": None}
+
+
+def test_nullable_absent_omitted():
+    assert validate({}, (Field("x", str, required=False, nullable=True),)) == {}
+
+
+def test_nullable_present_value_kept():
+    assert validate({"x": "hi"}, (Field("x", str, required=False, nullable=True),)) == {"x": "hi"}
+
+
+def test_nullable_present_wrong_type_rejected():
+    with pytest.raises(ValidationError) as e:
+        validate({"x": 5}, (Field("x", str, required=False, nullable=True),))
+    assert e.value.message == "x must be a string"
+
+
+def test_nullable_does_not_override_required():
+    with pytest.raises(ValidationError) as e:
+        validate({"x": None}, (Field("x", str, required=True, nullable=True),))
+    assert e.value.message == "x is required"
+
+
+def test_proof_token_update_schema():
+    # phase 4 (tokens): token_id coerce-int positive + nullable annotation fields.
+    schema = (
+        Field("token_id", int, coerce=True, min=1, error=BadRequestError),
+        Field("lemma", str, required=False, nullable=True, error=BadRequestError),
+    )
+    assert validate({"token_id": "5", "lemma": None}, schema) == {"token_id": 5, "lemma": None}
+    assert validate({"token_id": 5}, schema) == {"token_id": 5}
+    with pytest.raises(BadRequestError):
+        validate({"token_id": 0}, schema)  # not positive (min=1)
+    with pytest.raises(BadRequestError):
+        validate({"token_id": 5, "lemma": 9}, schema)  # lemma non-str
+
+
 # ─── strip (required non-blank string) ────────────────────────────────────────
 
 def test_strip_trims_value():


### PR DESCRIPTION
## A-03 lot 4 — option `nullable` + `tokens_service`

> ⚠️ **Stackée sur #95** (base = `feat/a03-validation-phase2-documents`). Merger #95 d'abord, puis je retarget/rebase sur `dev`. La diff ici ne montre que le lot 4.

Étend le valideur avec l'option **`nullable`** — le manque rencontré **3×** (documents `validated_run_id`, units `text_raw`/`text_norm`, tokens) — et le **prouve** en migrant `tokens_service`.

### Extension `nullable` (`services/validation.py`)
Champ **optionnel** où `null` est une valeur **valide** (gardée → `None`). Sans l'option, un `null` présent sur un champ optionnel est type-checké → rejeté (le défaut « isinstance-guard », inchangé). N'override pas `required` (required + null → `"is required"`).

### Migration `tokens_service.update_token` (`BadRequestError` préservé)
| Champ | Schéma |
|---|---|
| `token_id` | `Field(int, coerce=True, min=1)` — required + entier + **positif** (`≤0` → erreur via `min=1`) |
| `word` / `lemma` / `upos` / `xpos` / `feats` / `misc` | `Field(str, required=False, nullable=True)` — chaîne **ou null**, schéma splaté depuis `_TOKEN_UPDATABLE` |

`updates = {k: clean[k] for k in _TOKEN_UPDATABLE if k in clean}` reconstruit le dict (présent-null → `None`, absent → omis). **Inline** : check « no updatable fields » (cross-field) ; `list_tokens` (query-params, hors périmètre).

### Vérification
- `ruff check src tests` — OK
- `pytest` — **74 passed** : `test_validation.py` (56, dont 6 nullable + tokens-proof) + `test_tokens_service.py` (18, byte-identique)
- Wire `/tokens/*` (subprocess) → CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
