### PR TITLE
feat(engine): dériver IndexRequest du schéma Field — single source (A-03B pilote)

### DIFF
--- a/docs/TICKET_A03B_OPENAPI_FROM_FIELD.md
+++ b/docs/TICKET_A03B_OPENAPI_FROM_FIELD.md
@@ -1,0 +1,85 @@
+# TICKET — A-03B : dériver les `requestBody` OpenAPI des schémas `Field` (single source)
+
+> Suite du stretch §6 de `TICKET_A03_SCHEMA_VALIDATION.md` (A-03 clos). Objectif :
+> une **source unique** pour la validation **et** le contrat OpenAPI, là où c'est
+> atteignable sans régression — c.-à-d. un **pilote** prouvé, pas un big-bang.
+
+## 1. État des lieux (vérifié au code, 2026-06-21)
+
+- `openapi_spec()` (`src/multicorpus_engine/sidecar_contract.py`, ~3670 l.) déclare chaque `requestBody` **à la main** : un `$ref` → `#/components/schemas/XxxRequest`, et les `XxxRequest` sont des **JSON Schema écrits à la main** sous `components.schemas` (`type` / `properties` / `required` / `enum` / `nullable` / `description` / `additionalProperties`).
+- `scripts/export_openapi.py` sérialise `openapi_spec()` → `docs/openapi.json` (indent 2, `sort_keys=True`). Le **contract-freeze CI** exige que `docs/openapi.json` **et** `tests/snapshots/openapi_paths.json` matchent la sortie de `sidecar_contract.py`.
+- Les schémas **`Field`** (validation, `services/validation.py`) vivent **au point d'usage**, éparpillés (handlers `sidecar.py` + `services/*.py`), et **partiellement** : ex. `/export/conllu` n'a un `Field` que pour `out_path` (pas `doc_ids`) ; `/import` n'a **aucun** `Field` (validation dans `import_service`).
+- Exemple de référence — `IndexRequest` actuel :
+  ```json
+  {"type": "object",
+   "properties": {"incremental": {"type": "boolean", "description": "If true, runs incremental FTS sync …"}},
+   "additionalProperties": false}
+  ```
+  ⇄ schéma de validation `_handle_index` : `(Field("incremental", bool, required=False, default=False),)`.
+
+## 2. Contraintes (déterminantes pour le design)
+
+- **Contract-freeze = gate CI dur.** Toute dérivation doit produire un `openapi.json` soit **byte-identique**, soit dont le **diff est intentionnel, revu et régénéré** (`python scripts/export_openapi.py` + commit). *Aucun endpoint retiré* (règle existante).
+- **Pas de nouvelle dépendance runtime** (stdlib pur — la dérivation est du dict-building).
+- **Le growth-gate ne s'applique PAS** : il cible `sidecar.py`, pas `sidecar_contract.py`. Le code de génération va donc dans `sidecar_contract.py`/helper sans contrainte de lignes.
+- **3 obstacles structurels** (révélés à la reconnaissance — cadrent le périmètre) :
+  1. **Couverture** : les `Field` ne couvrent qu'une minorité d'endpoints, souvent partiellement. Dériver *tous* les `requestBody` supposerait d'écrire des `Field` complets partout = le travail qu'**A-03 a délibérément arrêté** (line-négatif). → **hors périmètre**.
+  2. **Perte d'info — champs ET types** (vérifié au code) :
+     - *champs* : les JSON Schema manuels portent la liste **complète** des champs ; ex. `POST /conventions` déclare `name, label, color, icon, sort_order`, mais `_CREATE_CONVENTION_SCHEMA` ne couvre que `name`+`label` → dériver **supprimerait** color/icon/sort_order du contrat.
+     - *types* : beaucoup de `Field` migrés sont **presence-only** (`type=object`, sans type) car écrits pour matcher byte-identique des gardes legacy lâches (`x is None`) ; les schémas OpenAPI sont **typés**. Ex. `POST /doc_relations/delete` déclare `id: {type: integer}`, mais `Field("id", required=True)` est typeless → dériver **perdrait `type: integer`**. Resserrer le `Field` (`type=int`) **changerait le comportement de validation** (presence-only accepte tout type ; `int` rejette) → re-vérification byte-identique par champ, hors périmètre ici.
+     - *descriptions* : `Field` n'a pas de `description` → il faut un **`Field.description`** optionnel.
+     - ⇒ **ne dériver QUE des schémas `Field` à couverture *complète* ET *typée*** ; sinon régression du contrat.
+  3. **Mismatch sémantique** : le valideur **ignore** les clés en trop (permissif, cf. `validate()` qui ne copie pas les clés hors-schéma) ; certains schémas (ex. `IndexRequest`) déclarent `additionalProperties: false` (strict), d'autres (ex. inline `POST /conventions`) **l'omettent**. → la dérivation **n'invente pas** `additionalProperties` depuis la sémantique du valideur ; elle l'émet comme **choix d'auteur** via un paramètre à **3 états** (`false` / `true` / *omis*) pour rester byte-identique selon le schéma cible. Durcir le valideur pour rejeter les extras est **hors périmètre** (changement de comportement).
+
+## 3. Design retenu — générateur `Field → JSON Schema`, piloté
+
+1. **Étendre `Field`** d'un attribut **`description: str | None = None`** (frozen dataclass ; n'affecte pas `validate()`). Rétro-compatible (défaut `None`).
+2. **Générateur** `field_schema_to_openapi(schema: Sequence[Field], *, additional_properties: bool | None = False, include_default: bool = False) -> dict` (dans `sidecar_contract.py` ou un helper qu'il importe). `additional_properties` à 3 états : `False`/`True` émet la clé, `None` l'**omet**. Mapping :
+   - `type` → `{"type": <nom JSON>}` (réutiliser `_TYPE_NAMES` de `validation.py` ; tuple → `oneOf`/union si rencontré, sinon scalaire) ; `object` (pas de type) → pas de clé `type` ;
+   - `required=True` → ajouté au tableau `required` (omis si vide, pour matcher l'existant) ;
+   - `enum` → `"enum"` ; `min`/`max` → `minimum`/`maximum` (numérique) ou `minLength`/`maxLength` (str) ou `minItems`/`maxItems` (list) selon `type` ;
+   - `default` (si `≠ _UNSET`) → `"default"` — **émission togglable** (`include_default: bool`), car l'`IndexRequest` actuel n'a PAS de `default` : le pilote choisit byte-identique (supprimer) vs documenté (émettre + régénérer le freeze) ;
+   - `items` → `{"items": {"type": …}}` ; `nullable=True` → `"nullable": true` ;
+   - `description` → `"description"` (si non `None`) ;
+   - conteneur : `{"type": "object", "properties": {…}, [required], "additionalProperties": <param>}`.
+3. **Source unique des schémas de requête** : déposer les `Field`-tuples **canoniques** dans un endroit unique (ex. constantes dans `sidecar_contract.py`, ou `services/request_schemas.py`) que **les deux** consomment — le handler (`validate(body, SCHEMA)`) **et** `openapi_spec()` (`field_schema_to_openapi(SCHEMA)`). Pour le pilote : extraire le `_INDEX_SCHEMA` aujourd'hui inline dans `_handle_index`.
+4. **Pilote = `/index`** (seul endpoint à couverture `Field` *complète ET typée* : 1 champ `bool`). Cible : `field_schema_to_openapi(_INDEX_SCHEMA, additional_properties=False, include_default=False)` **reproduit byte-identique l'`IndexRequest` actuel** (`Field.description` portant le texte existant ; `default` supprimé via le toggle). Si on préfère *documenter* le défaut (`include_default=True`), l'écart (`"default": false`) est assumé et le freeze régénéré — décision à acter en phase 1.
+
+## 4. Décomposition (incrémentale, modèle A-03)
+
+1. **Phase 1 — socle + pilote `/index`** : `Field.description` + `field_schema_to_openapi` + tests unitaires du générateur (chaque facette → fragment JSON Schema attendu) ; extraire `_INDEX_SCHEMA` en source unique ; brancher `IndexRequest` sur le générateur ; **régénérer `docs/openapi.json` + snapshot** et faire passer le contract-freeze (diff revu). Vérifier `/index` toujours byte-identique côté validation.
+2. **Phases 2..N — quasi vides aujourd'hui, à NE PAS forcer** : audit au code (2026-06-21) — *aucun* autre endpoint migré n'est un candidat propre : `conventions/create` est **partiel** (color/icon/sort_order absents du `Field`), `doc_relations/delete` / `documents/*` / `units/*` ont des `Field` **type-lâches** (presence-only) qui perdraient le `type` OpenAPI, l'export est partiel (`out_path` seul). Étendre exige d'abord de **compléter + typer** les `Field` — donc de **rouvrir le travail qu'A-03 a arrêté** (line-négatif) et de **re-vérifier le byte-identique** de validation à chaque resserrage de type. ⇒ traiter ces endpoints **un par un, seulement si justifié**, jamais en masse. Réaliste : `/index` est ~tout le périmètre proprement dérivable en l'état.
+3. **Clôture** : générateur + `Field.description` + `/index` dérivé prouvé en CI ; décisions `additionalProperties` / `default` / type-looseness documentées ; **extension = backlog explicitement gated** sur la complétude+typage des `Field`. Le livrable réel d'A-03B est donc **l'outil + la preuve + le gate documenté**, pas une couverture large.
+
+## 5. Risques & mitigations
+
+- **Diff de freeze non maîtrisé** ⇒ régénérer via `scripts/export_openapi.py`, **review du diff JSON** par endpoint ; viser le byte-identique, sinon écart intentionnel documenté en commit.
+- **Dérive de doc (perte de `description`/champs)** ⇒ ne dériver QUE des `Field` complets + `Field.description` obligatoire là où l'existant en a un ; test comparant le `requestBody` généré à l'attendu.
+- **Mismatch `additionalProperties`** ⇒ paramètre explicite 3 états (`false`/`true`/`None`=omis), **pas** dérivé du valideur ; durcissement du valideur hors périmètre.
+- **Couplage `sidecar_contract` → `services.validation`** ⇒ import unidirectionnel (contrat dépend de la validation, jamais l'inverse) ; pas de cycle.
+
+## 6. Définition de fini (pilote)
+
+- `Field.description` ajouté (rétro-compatible) ; `validate()` inchangé ; tests valideur toujours verts.
+- `field_schema_to_openapi()` + tests unitaires (toutes facettes).
+- `/index` : `IndexRequest` **dérivé** de `_INDEX_SCHEMA` (source unique handler + contrat) ; `docs/openapi.json` + snapshot régénérés ; **contract-freeze vert en CI** ; `/index` validation byte-identique.
+- Décisions documentées (ce ticket ou `DECISIONS.md`) : `additionalProperties` (param 3 états), `default` (toggle), **type-looseness** (pourquoi on ne resserre pas les `Field` migrés), et le **gate d'extension** (complétude+typage requis).
+- **Aucune** nouvelle dépendance.
+
+## 7. Clôture — pilote livré (2026-06-21)
+
+**Livré** (le livrable réel = **l'outil + la preuve + le gate**, pas une couverture large) :
+
+- **`Field.description`** ajouté (`services/validation.py`, frozen dataclass, défaut `None`, **en queue** des champs → rétro-compat positionnelle). Pure métadonnée : `validate()` ne le lit jamais → validation byte-identique (vérifié sur `{}`, `{incremental:true}`, `{incremental:"yes"}`, `{incremental:null}`, non-objet).
+- **`field_schema_to_openapi()`** + `INDEX_SCHEMA` dans le **nouveau module `services/request_schemas.py`** (single source consommée par `_handle_index` **et** `openapi_spec()`). Couplage unidirectionnel `sidecar_contract → request_schemas → validation` (zéro cycle). Stdlib pur, **aucune** dépendance.
+- **Pilote `/index`** : `IndexRequest` dérivé de `INDEX_SCHEMA` → **byte-identique** à l'ancien schéma manuel (freeze CI vert, `docs/openapi.json` + snapshot **inchangés** — `scripts/export_openapi.py` produit zéro diff). `_handle_index` valide contre le **même** `INDEX_SCHEMA`.
+- **Tests** : `tests/services/test_request_schemas.py` (26) — byte-identité du pilote (vs schéma attendu, vs spec live, vs `docs/openapi.json` commité) + chaque facette (type scalaire / sentinel `object` sans `type` / tuple→`oneOf` / `required` listé+omis-si-vide / `enum` / bornes num→`minimum`-`maximum`, str→`minLength`-`maxLength`, list→`minItems`-`maxItems`, dict→`minProperties`-`maxProperties` / `items` / `nullable` / toggle `default` on-off-unset / `description` / `additionalProperties` 3 états) + `description` ignorée par `validate()`.
+
+**Décisions actées** (cf. §2, §3) :
+
+- **`additionalProperties` = choix d'auteur 3 états** (`False`/`True` émettent, `None` **omet**), **pas** dérivé de la sémantique (permissive) du valideur. Durcir le valideur pour rejeter les extras reste **hors périmètre** (changement de comportement). Pilote : `False`.
+- **`default` = toggle** (`include_default`). Pilote : **off** → `default` supprimé pour matcher l'`IndexRequest` historique (qui n'en portait pas). Documenter le défaut = `include_default=True` + régénérer le freeze (écart assumé).
+- **Type-looseness — on NE resserre PAS les `Field` migrés.** Beaucoup sont presence-only (`type=object`) pour matcher byte-identique des gardes legacy lâches ; resserrer (`type=int`…) **changerait la validation** (presence-only accepte tout type, `int` rejette) → bascule 200→400. Le générateur respecte le `Field` tel quel (`object` → pas de clé `type`).
+- **Gate d'extension** (backlog explicite) : un endpoint n'est dérivable proprement **que si** son `Field`-schéma est **complet** (tous les champs du contrat) **ET typé** (pas de presence-only là où le contrat est typé). Sinon la dérivation **supprime** des propriétés ou perd le `type`. Étendre exige donc de **compléter + typer** les `Field` d'abord — soit **rouvrir le travail line-négatif qu'A-03 a arrêté** + re-vérifier le byte-identique par champ. ⇒ endpoint par endpoint, **jamais en masse**. En l'état, **`/index` est ~tout le périmètre proprement dérivable**.
+
+🏁 **A-03B clos sur le pilote.** Extension = backlog gated (complétude+typage des `Field`).

--- a/src/multicorpus_engine/services/request_schemas.py
+++ b/src/multicorpus_engine/services/request_schemas.py
@@ -1,0 +1,138 @@
+"""Canonical request schemas + ``Field → JSON Schema`` generator (audit A-03B).
+
+A **single source** for both the structural validator and the OpenAPI contract.
+A request schema is declared once as a tuple of :class:`~.validation.Field`; the
+handler feeds it to :func:`~.validation.validate` while ``sidecar_contract`` feeds
+it to :func:`field_schema_to_openapi` to build the ``requestBody`` JSON Schema —
+so validation and documentation can never drift.
+
+Coupling is **unidirectional**: ``sidecar_contract`` (contract) depends on this
+module, which depends on ``validation`` (the validator). The validator never
+imports the contract — no cycle. ``_TYPE_NAMES`` / ``_UNSET`` are reused from
+``validation`` on purpose (they are the validator's authoritative type map and
+"absent" sentinel).
+
+Scope = **pilot** (A-03B): only ``/index`` is derived today. Extending to other
+endpoints is explicitly gated on first **completing + typing** their ``Field``
+schemas — a derivation only stays byte-identical when the ``Field`` carries the
+*complete* field list and a *concrete* type (a presence-only / partial schema
+would silently drop ``type`` or whole properties from the contract). See the
+ticket ``docs/TICKET_A03B_OPENAPI_FROM_FIELD.md`` §4.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from .validation import _TYPE_NAMES, _UNSET, Field
+
+
+def _apply_type(prop: dict[str, Any], t: type | tuple[type, ...]) -> None:
+    """Emit the OpenAPI ``type`` (or ``oneOf`` union) for a Field's declared type.
+
+    ``object`` is the validator's "no type check" sentinel — it emits no ``type``
+    key (matching hand-written schemas that omit it for presence-only fields).
+    A single python type maps via ``_TYPE_NAMES``; a tuple becomes ``oneOf`` (or a
+    bare ``type`` when it collapses to one known name) since OpenAPI 3.0 has no
+    type-array.
+    """
+    if isinstance(t, tuple):
+        names = [name for name in (_TYPE_NAMES.get(x) for x in t) if name]
+        if len(names) == 1:
+            prop["type"] = names[0]
+        elif names:
+            prop["oneOf"] = [{"type": name} for name in names]
+        return
+    if t is object:
+        return
+    name = _TYPE_NAMES.get(t)
+    if name is not None:
+        prop["type"] = name
+
+
+def _bounds_keys(t: type | tuple[type, ...]) -> tuple[str, str]:
+    """``(min_key, max_key)`` chosen by the Field's declared type.
+
+    Mirrors how ``validate()`` interprets ``min``/``max`` at runtime: a length
+    bound for ``str``, a size bound for ``list``/``dict``, else a numeric bound.
+    """
+    if t is str:
+        return "minLength", "maxLength"
+    if t is list or (isinstance(t, tuple) and list in t):
+        return "minItems", "maxItems"
+    if t is dict:
+        return "minProperties", "maxProperties"
+    return "minimum", "maximum"
+
+
+def field_schema_to_openapi(
+    schema: Sequence[Field],
+    *,
+    additional_properties: bool | None = False,
+    include_default: bool = False,
+) -> dict[str, Any]:
+    """Build an OpenAPI ``object`` JSON Schema from a ``Field`` tuple.
+
+    ``additional_properties`` is a **3-state author choice**, NOT derived from the
+    validator's (permissive) semantics: ``False``/``True`` emit the key, ``None``
+    omits it — so the output can match either a strict (``additionalProperties:
+    false``) or a key-omitting hand-written schema byte-for-byte.
+
+    ``include_default`` toggles emission of ``default`` (when the Field declares
+    one): off by default because several existing schemas document the field
+    without a ``default`` and must stay byte-identical; turn it on to document the
+    default and regenerate the freeze.
+    """
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for f in schema:
+        prop: dict[str, Any] = {}
+        _apply_type(prop, f.type)
+        if f.enum is not None:
+            prop["enum"] = list(f.enum)
+        if f.min is not None or f.max is not None:
+            min_key, max_key = _bounds_keys(f.type)
+            if f.min is not None:
+                prop[min_key] = f.min
+            if f.max is not None:
+                prop[max_key] = f.max
+        if f.items is not None:
+            item_name = None if isinstance(f.items, tuple) else _TYPE_NAMES.get(f.items)
+            prop["items"] = {"type": item_name} if item_name else {}
+        if f.nullable:
+            prop["nullable"] = True
+        if include_default and f.default is not _UNSET:
+            prop["default"] = f.default
+        if f.description is not None:
+            prop["description"] = f.description
+        properties[f.name] = prop
+        if f.required:
+            required.append(f.name)
+
+    out: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:  # omit the empty array to match the existing hand-written schemas
+        out["required"] = required
+    if additional_properties is not None:
+        out["additionalProperties"] = additional_properties
+    return out
+
+
+# ─── Canonical request schemas (single source: handler + contract) ────────────
+
+# POST /index — the A-03B pilot. The lone field is fully typed (``bool``) and the
+# schema is complete, so `field_schema_to_openapi(INDEX_SCHEMA,
+# additional_properties=False, include_default=False)` reproduces the historical
+# `IndexRequest` byte-for-byte (default dropped via the toggle; description carried
+# on the Field). `_handle_index` validates against this exact same tuple.
+INDEX_SCHEMA: tuple[Field, ...] = (
+    Field(
+        "incremental",
+        bool,
+        required=False,
+        default=False,
+        description=(
+            "If true, runs incremental FTS sync (insert/refresh/prune) "
+            "instead of full rebuild."
+        ),
+    ),
+)

--- a/src/multicorpus_engine/services/validation.py
+++ b/src/multicorpus_engine/services/validation.py
@@ -74,6 +74,12 @@ class Field:
     items    for a list / tuple, the required element type:
              ``"<name> must be a list of …s"``.
     error    typed error class to raise (``ValidationError`` or ``BadRequestError``).
+    description
+             optional human-readable text. **Pure metadata** — ``validate()``
+             ignores it entirely; it is consumed only by the OpenAPI generator
+             (``services.request_schemas.field_schema_to_openapi``) so a single
+             ``Field`` schema can be the source for both validation and the
+             contract ``requestBody`` (audit A-03B).
     """
 
     name: str
@@ -88,6 +94,7 @@ class Field:
     nullable: bool = False
     items: type | tuple[type, ...] | None = None
     error: type[ServiceError] = ValidationError
+    description: str | None = None
 
 
 def validate(

--- a/src/multicorpus_engine/sidecar.py
+++ b/src/multicorpus_engine/sidecar.py
@@ -2076,13 +2076,16 @@ class _CorpusHandler(BaseHTTPRequestHandler):
     def _handle_index(self, body: dict) -> None:
         from multicorpus_engine.indexer import build_index, update_index
         from multicorpus_engine.services.errors import ValidationError
-        from multicorpus_engine.services.validation import Field, validate
+        from multicorpus_engine.services.request_schemas import INDEX_SCHEMA
+        from multicorpus_engine.services.validation import validate
 
         # A-03: structural validation via declarative schema. The validator raises
         # the typed error; the handler maps it to the historical wire code (here
         # ERR_VALIDATION) — same catch→_send_error shape as _handle_import.
+        # A-03B: INDEX_SCHEMA is the single source — the same tuple also derives the
+        # OpenAPI IndexRequest in sidecar_contract.py (validation ⇄ contract can't drift).
         try:
-            clean = validate(body, (Field("incremental", bool, required=False, default=False),))
+            clean = validate(body, INDEX_SCHEMA)
         except ValidationError as exc:
             self._send_error(exc.message, code=ERR_VALIDATION, http_status=400)
             return

--- a/src/multicorpus_engine/sidecar_contract.py
+++ b/src/multicorpus_engine/sidecar_contract.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .services.request_schemas import INDEX_SCHEMA, field_schema_to_openapi
+
 
 API_VERSION = "1.6.23"
 CONTRACT_VERSION = "1.6.27"  # semantic versioning for the sidecar API contract
@@ -2254,19 +2256,12 @@ def openapi_spec() -> dict[str, Any]:
                         },
                     ]
                 },
-                "IndexRequest": {
-                    "type": "object",
-                    "properties": {
-                        "incremental": {
-                            "type": "boolean",
-                            "description": (
-                                "If true, runs incremental FTS sync (insert/refresh/prune) "
-                                "instead of full rebuild."
-                            ),
-                        },
-                    },
-                    "additionalProperties": False,
-                },
+                # A-03B pilot: derived from the canonical INDEX_SCHEMA (single
+                # source shared with _handle_index). Byte-identical to the former
+                # hand-written schema — see services/request_schemas.py.
+                "IndexRequest": field_schema_to_openapi(
+                    INDEX_SCHEMA, additional_properties=False, include_default=False
+                ),
                 "ImportRequest": {
                     "type": "object",
                     "required": ["mode", "path"],

--- a/tests/services/test_request_schemas.py
+++ b/tests/services/test_request_schemas.py
@@ -1,0 +1,252 @@
+"""Unit tests for the ``Field → JSON Schema`` generator (audit A-03B).
+
+Pure unit tests — no sidecar subprocess, no DB. Two concerns:
+
+1. **Pilot byte-identity**: deriving ``IndexRequest`` from ``INDEX_SCHEMA`` must
+   reproduce the historical hand-written schema exactly (the contract-freeze gate).
+2. **Generator facets**: every mapping rule (type / required / enum / bounds /
+   items / nullable / default toggle / description / additionalProperties 3-state)
+   maps a ``Field`` to the expected JSON Schema fragment.
+
+Plus: ``Field.description`` is pure metadata — ``validate()`` must ignore it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from multicorpus_engine.services.errors import ValidationError
+from multicorpus_engine.services.request_schemas import (
+    INDEX_SCHEMA,
+    field_schema_to_openapi,
+)
+from multicorpus_engine.services.validation import Field, validate
+
+
+# ─── Pilot: /index byte-identity ──────────────────────────────────────────────
+
+EXPECTED_INDEX_REQUEST = {
+    "type": "object",
+    "properties": {
+        "incremental": {
+            "type": "boolean",
+            "description": (
+                "If true, runs incremental FTS sync (insert/refresh/prune) "
+                "instead of full rebuild."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+def test_index_schema_derives_historical_index_request():
+    derived = field_schema_to_openapi(
+        INDEX_SCHEMA, additional_properties=False, include_default=False
+    )
+    assert derived == EXPECTED_INDEX_REQUEST
+
+
+def test_derived_index_request_matches_live_spec():
+    from multicorpus_engine.sidecar_contract import openapi_spec
+
+    spec = openapi_spec()
+    assert spec["components"]["schemas"]["IndexRequest"] == EXPECTED_INDEX_REQUEST
+
+
+def test_derived_index_request_matches_committed_openapi_json():
+    """The frozen docs/openapi.json must carry exactly the derived schema."""
+    repo_root = Path(__file__).resolve().parents[2]
+    committed = json.loads((repo_root / "docs" / "openapi.json").read_text(encoding="utf-8"))
+    assert committed["components"]["schemas"]["IndexRequest"] == EXPECTED_INDEX_REQUEST
+
+
+# ─── type mapping ─────────────────────────────────────────────────────────────
+
+def test_scalar_types_map_to_json_names():
+    schema = (
+        Field("b", bool, required=False),
+        Field("s", str, required=False),
+        Field("i", int, required=False),
+        Field("f", float, required=False),
+        Field("d", dict, required=False),
+        Field("a", list, required=False),
+    )
+    props = field_schema_to_openapi(schema)["properties"]
+    assert props["b"] == {"type": "boolean"}
+    assert props["s"] == {"type": "string"}
+    assert props["i"] == {"type": "integer"}
+    assert props["f"] == {"type": "number"}
+    assert props["d"] == {"type": "object"}
+    assert props["a"] == {"type": "array"}
+
+
+def test_object_sentinel_emits_no_type_key():
+    # ``object`` is the validator's "no type check" default → presence-only field.
+    props = field_schema_to_openapi((Field("x", required=False),))["properties"]
+    assert props["x"] == {}
+    assert "type" not in props["x"]
+
+
+def test_tuple_type_emits_oneof_union():
+    props = field_schema_to_openapi(
+        (Field("x", (int, float), required=False),)
+    )["properties"]
+    assert props["x"] == {"oneOf": [{"type": "integer"}, {"type": "number"}]}
+
+
+def test_tuple_type_collapsing_to_one_known_name_is_bare_type():
+    # A tuple where only one member is a known JSON type collapses to a plain type.
+    props = field_schema_to_openapi(
+        (Field("x", (str, object), required=False),)
+    )["properties"]
+    assert props["x"] == {"type": "string"}
+
+
+# ─── required ─────────────────────────────────────────────────────────────────
+
+def test_required_fields_listed_optionals_excluded():
+    schema = (
+        Field("a", str, required=True),
+        Field("b", str, required=False),
+        Field("c", int, required=True),
+    )
+    out = field_schema_to_openapi(schema)
+    assert out["required"] == ["a", "c"]
+
+
+def test_empty_required_array_is_omitted():
+    out = field_schema_to_openapi((Field("a", str, required=False),))
+    assert "required" not in out
+
+
+# ─── enum / bounds / items / nullable ─────────────────────────────────────────
+
+def test_enum_emitted_as_list():
+    props = field_schema_to_openapi(
+        (Field("mode", str, required=False, enum=("kwic", "segment")),)
+    )["properties"]
+    assert props["mode"]["enum"] == ["kwic", "segment"]
+
+
+def test_numeric_bounds_map_to_minimum_maximum():
+    props = field_schema_to_openapi(
+        (Field("n", int, required=False, min=1, max=200),)
+    )["properties"]
+    assert props["n"]["minimum"] == 1
+    assert props["n"]["maximum"] == 200
+    assert "minLength" not in props["n"]
+
+
+def test_string_bounds_map_to_min_max_length():
+    props = field_schema_to_openapi(
+        (Field("s", str, required=False, min=1, max=64),)
+    )["properties"]
+    assert props["s"]["minLength"] == 1
+    assert props["s"]["maxLength"] == 64
+    assert "minimum" not in props["s"]
+
+
+def test_list_bounds_map_to_min_max_items():
+    props = field_schema_to_openapi(
+        (Field("xs", list, required=False, min=1, max=10),)
+    )["properties"]
+    assert props["xs"]["minItems"] == 1
+    assert props["xs"]["maxItems"] == 10
+
+
+def test_dict_bounds_map_to_min_max_properties():
+    props = field_schema_to_openapi(
+        (Field("m", dict, required=False, min=1),)
+    )["properties"]
+    assert props["m"]["minProperties"] == 1
+
+
+def test_items_element_type_emitted():
+    props = field_schema_to_openapi(
+        (Field("ids", list, required=False, items=int),)
+    )["properties"]
+    assert props["ids"]["items"] == {"type": "integer"}
+
+
+def test_nullable_emits_nullable_true():
+    props = field_schema_to_openapi(
+        (Field("note", str, required=False, nullable=True),)
+    )["properties"]
+    assert props["note"]["nullable"] is True
+
+
+# ─── default toggle ───────────────────────────────────────────────────────────
+
+def test_default_dropped_when_include_default_false():
+    props = field_schema_to_openapi(
+        (Field("x", bool, required=False, default=False),)
+    )["properties"]
+    assert "default" not in props["x"]
+
+
+def test_default_emitted_when_include_default_true():
+    props = field_schema_to_openapi(
+        (Field("x", bool, required=False, default=False),),
+        include_default=True,
+    )["properties"]
+    assert props["x"]["default"] is False
+
+
+def test_default_not_emitted_when_unset_even_if_toggled():
+    # A Field that declares no default stays default-less even with the toggle on.
+    props = field_schema_to_openapi(
+        (Field("x", bool, required=False),),
+        include_default=True,
+    )["properties"]
+    assert "default" not in props["x"]
+
+
+# ─── description ──────────────────────────────────────────────────────────────
+
+def test_description_emitted_when_set():
+    props = field_schema_to_openapi(
+        (Field("x", bool, required=False, description="hello"),)
+    )["properties"]
+    assert props["x"]["description"] == "hello"
+
+
+def test_description_omitted_when_none():
+    props = field_schema_to_openapi((Field("x", bool, required=False),))["properties"]
+    assert "description" not in props["x"]
+
+
+# ─── additionalProperties — 3-state author choice ─────────────────────────────
+
+def test_additional_properties_false_emitted():
+    out = field_schema_to_openapi((Field("x", str, required=False),), additional_properties=False)
+    assert out["additionalProperties"] is False
+
+
+def test_additional_properties_true_emitted():
+    out = field_schema_to_openapi((Field("x", str, required=False),), additional_properties=True)
+    assert out["additionalProperties"] is True
+
+
+def test_additional_properties_none_omits_key():
+    out = field_schema_to_openapi((Field("x", str, required=False),), additional_properties=None)
+    assert "additionalProperties" not in out
+
+
+# ─── Field.description is pure metadata (validate ignores it) ──────────────────
+
+def test_description_does_not_affect_validation_success():
+    plain = validate({"x": True}, (Field("x", bool, required=False),))
+    described = validate(
+        {"x": True}, (Field("x", bool, required=False, description="doc"),)
+    )
+    assert plain == described == {"x": True}
+
+
+def test_description_does_not_affect_validation_error():
+    with pytest.raises(ValidationError) as e:
+        validate({"x": "no"}, (Field("x", bool, required=False, description="doc"),))
+    assert e.value.message == "x must be a boolean"


### PR DESCRIPTION
## A-03B — dériver les `requestBody` OpenAPI des schémas `Field` (single source), pilote `/index`

Suite du stretch §6 d'A-03. Objectif : **une source unique** pour la validation *et* le contrat OpenAPI, prouvée sur un **pilote** (`/index`), pas en big-bang. Livrable = **l'outil + la preuve + le gate documenté**.

### Ce que ça fait
Le `requestBody` OpenAPI de `/index` (`IndexRequest`) n'est plus écrit à la main : il est **dérivé** du même tuple `Field` qui sert à la validation, via `field_schema_to_openapi()`. Validation ⇄ contrat ne peuvent plus diverger.

### Changements
- **`Field.description`** (`services/validation.py`) — ajouté en **queue** du dataclass (rétro-compat positionnelle, défaut `None`). Pure métadonnée : `validate()` ne le lit jamais.
- **`services/request_schemas.py`** *(nouveau)* — le générateur `field_schema_to_openapi()` + la constante canonique `INDEX_SCHEMA`. Couplage **unidirectionnel** `sidecar_contract → request_schemas → validation` (zéro cycle), **stdlib pur**.
- **`sidecar_contract.py`** — `IndexRequest` dérivé de `INDEX_SCHEMA`.
- **`sidecar.py`** — `_handle_index` valide contre le **même** `INDEX_SCHEMA` (net +3 lignes, growth-gate ok).

### Preuve
- **Byte-identique** : `scripts/export_openapi.py` produit **zéro diff** → `docs/openapi.json` + snapshot inchangés, **contract-freeze CI vert**.
- **Validation `/index` inchangée** : identique sur `{}`, `{incremental:true}`, `{incremental:"yes"}`, `{incremental:null}`, non-objet (piège *present-null* inclus). Classe d'erreur attrapée toujours `ValidationError`.
- **26 tests** (`tests/services/test_request_schemas.py`) : byte-identité du pilote (vs attendu, vs spec live, vs `docs/openapi.json`) + chaque facette du générateur (type / `object` sans `type` / tuple→`oneOf` / `required` listé+omis-si-vide / `enum` / bornes num·str·list·dict / `items` / `nullable` / toggle `default` / `description` / `additionalProperties` 3 états) + `description` ignorée par `validate()`.
- Local : `ruff check src tests` ✓ ; `tests/services/` (130) + `test_validation` + freeze ✓. Tests wire sidecar = CI (subprocess).

### Décisions actées (ticket §7)
- `additionalProperties` = **choix d'auteur 3 états** (`False`/`True`/`None`=omis), **pas** dérivé du valideur. Durcir le valideur = hors périmètre.
- `default` = **toggle** (`include_default`) ; off au pilote pour matcher l'`IndexRequest` historique.
- **Type-looseness** : on **ne resserre pas** les `Field` migrés (presence-only) — ça changerait la validation (200→400).
- **Gate d'extension** : un endpoint n'est dérivable que si son `Field` est **complet ET typé** ; sinon la dérivation perd des champs / le `type`. ⇒ endpoint par endpoint, jamais en masse. En l'état, `/index` est ~tout le périmètre proprement dérivable.

**Aucune nouvelle dépendance.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
